### PR TITLE
Improve the SHACL rules

### DIFF
--- a/rdf/shape.ttl
+++ b/rdf/shape.ttl
@@ -10,14 +10,15 @@
 # 1. Multilingual Labels for Key Entities
 #    - For every instance of:
 #      schema:Organization, schema:SoftwareApplication, systemmap:Information
-#      => Must have at least one rdfs:label @de and at least one rdfs:label @fr
+#      => Must have at least one rdfs:label @de
 # ------------------------------------------------------------------------------
 
 :MultilingualLabelShape
     a sh:NodeShape ;
     sh:targetClass schema:Organization,
-                   schema:SoftwareApplication,
-                   systemmap:Information ;
+        schema:Legislation,
+        schema:SoftwareApplication,
+        systemmap:Information ;
 
     # Must have at least one label in German
     sh:property [
@@ -37,7 +38,7 @@
 # ------------------------------------------------------------------------------
 # 2. Multilingual Comments for IT Systems
 #    - Every instance of schema:SoftwareApplication => Must have
-#      at least one rdfs:comment @de AND at least one @fr
+#      at least one rdfs:comment @de
 # ------------------------------------------------------------------------------
 
 :SoftwareApplicationMultilingualCommentShape

--- a/rdf/shape.ttl
+++ b/rdf/shape.ttl
@@ -87,3 +87,27 @@
         sh:minCount 1 ;
         sh:message "Every piece of information (systemmap:Information) must be contained in at least one IT system (schema:SoftwareApplication)."
     ] .
+
+# ------------------------------------------------------------------------------
+# 5. Unique Language Constraint for rdfs:label and rdfs:comment
+#    - Every node can have at most one rdfs:label per language and at most one
+#      rdfs:comment per language.
+# ------------------------------------------------------------------------------
+
+:UniqueLangLabelShape
+    a sh:NodeShape ;
+    sh:targetSubjectsOf rdfs:label ;
+    sh:property [
+        sh:path rdfs:label ;
+        sh:uniqueLang true ;
+        sh:message "Each node must have at most one rdfs:label per language."
+    ] .
+
+:UniqueLangCommentShape
+    a sh:NodeShape ;
+    sh:targetSubjectsOf rdfs:comment ;
+    sh:property [
+        sh:path rdfs:comment ;
+        sh:uniqueLang true ;
+        sh:message "Each node must have at most one rdfs:comment per language."
+    ] .


### PR DESCRIPTION
- Add `schema:Legislation` for list of class with required labels
- Allow only one `rdfs:label` and `rdfs:comment` per object and language.

(Work on #34)