### PR TITLE
Use non-speaking nano-ID as URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ upload.sh
 notes.md
 prompt.md
 rdf/test.ttl
+rdf/graph.ttl

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -161,6 +161,11 @@ systemmap:daccec1f3b64441f98b234bdd8b874dd a schema:Organization ;
 
 systemmap:1f309b91ad564bcb99dd6c8c30bbc0dc a schema:SoftwareApplication ;
     rdfs:label "Troup'O Herdenmanager"@de ;
+    rdfs:comment """
+        Troup'O ist eine Herdenmanagement-Software für Milchvieh-, Mutterkuh- und Mastbetriebe, die eine zentrale Verwaltung von Zuchtdaten, eine übersichtliche Tierkartei und grafische Analysen bietet.
+        Die dazugehörige Smartphone-App ermöglicht es, Ereignisse wie Reproduktion, Behandlungen und Tierbewegungen in Echtzeit zu dokumentieren und funktioniert auch ohne Netzwerkabdeckung.
+        Dank RFID-Kompatibilität und einer intuitiven Benutzeroberfläche erleichtert Troup'O das Herdenmanagement und steigert die Betriebseffizienz.
+        """@de ;
     systemmap:operatedBy zefix:505628 .
 
 systemmap:SYS001 a schema:SoftwareApplication ;
@@ -989,6 +994,10 @@ systemmap:SYS042 a schema:SoftwareApplication ;
 
 systemmap:f4c51499ef7f40e6ac4ec446f508a9bb a schema:SoftwareApplication ;
     rdfs:label "Mooh Intranet"@de ;
+    rdfs:comment """
+        Intranet-Seite der Mooh Genossenschaft.
+        """@de ;
+    dcat:landingPage <https://intranet.mooh.swiss/> ;
     systemmap:operatedBy zefix:1256441 .
 
 systemmap:ORG300 a systemmap:CantonalOrganization ;

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -88,7 +88,26 @@ LwG:art_27 a schema:Legislation ;
 <https://www.fedlex.admin.ch/eli/cc/2016/565> a schema:Legislation ;
     rdfs:label "Verordnung des BLW über die Festlegung von Perioden und Fristen sowie die Freigabe von Zollkontingentsteilmengen für die Einfuhr von frischem Gemüse und frischem Obst (VEAGOG-Freigabeverordnung)"@de .
 
-systemmap:ORG200 a schema:Organization ;
+systemmap:Q6VSaFePQaMGqU8vD a schema:Organization ;
+    rdfs:label "Schweizer Bundesarchiv"@de,
+        "Swiss Federal Archives"@en,
+        "Archives fédérales suisses"@fr,
+        "Archivio federale svizzero"@it ;
+    rdfs:comment """
+        Das Schweizerische Bundesarchiv (BAR) sichert die Dokumentation staatlichen Handelns und macht diese zugänglich.
+        """@de,
+        """The Swiss Federal Archives (SFA) preserve the documentation of government actions and make it accessible.
+        """@en,
+        """Les Archives fédérales suisses (AFS) garantissent la conservation et l’accès des documents en lien avec les activités de l’Etat.
+        """@fr,
+        """L’Archivio federale svizzero (AFS) assicura la conservazione e l’accessibilità della documentazione dell’operato dello Stato.
+        """@it ;
+    systemmap:abbreviation "BAR"@de,
+        "SFA"@en,
+        "AFS"@fr,
+        "AFS"@it .
+
+systemmap:QBLH2G6TSKaqhqk4n a schema:Organization ;
     rdfs:label "Internationale Union zum Schutz von Pflanzenzüchtungen"@de,
         "International Union for the Protection of New Varieties of Plants"@en,
         "Union internationale pour la protection des obtentions végétales"@fr,
@@ -111,37 +130,14 @@ systemmap:ORG200 a schema:Organization ;
         "UPOV"@fr,
         "UPOV"@it .
 
-systemmap:ORG215 a schema:Organization ;
-    rdfs:label "Schweizer Bundesarchiv"@de,
-        "Swiss Federal Archives"@en,
-        "Archives fédérales suisses"@fr,
-        "Archivio federale svizzero"@it ;
-    rdfs:comment """
-        Das Schweizerische Bundesarchiv (BAR) sichert die Dokumentation staatlichen Handelns und macht diese zugänglich.
-        """@de,
-        """The Swiss Federal Archives (SFA) preserve the documentation of government actions and make it accessible.
-        """@en,
-        """Les Archives fédérales suisses (AFS) garantissent la conservation et l’accès des documents en lien avec les activités de l’Etat.
-        """@fr,
-        """L’Archivio federale svizzero (AFS) assicura la conservazione e l’accessibilità della documentazione dell’operato dello Stato.
-        """@it ;
-    systemmap:abbreviation "BAR"@de,
-        "SFA"@en,
-        "AFS"@fr,
-        "AFS"@it .
-
-systemmap:ORG999 a schema:Organization ;
-    rdfs:label "Europäische Kommission"@de,
-        "European Commission"@en .
-
-systemmap:daccec1f3b64441f98b234bdd8b874dd a schema:Organization ;
+systemmap:QGayLcAMcywbigd3M a schema:Organization ;
     rdfs:label "Gemeinsame Anmeldestelle Chemikalien"@de,
         "Common Notification Authority for Chemicals"@en,
         "Autorité commune de notification des produits chimiques"@fr,
         "Autorità comune di notifica delle sostanze chimiche"@it ;
-    schema:member systemmap:101f4674d4654b12bc25fa4a3143f32a,
-        systemmap:4e8ca1ec6eeb4786808a5f71486c4bbf,
-        systemmap:5044e9f5dc4347288f5506de98be40af ;
+    schema:member systemmap:Q2QF8BOhJczC0PGhe,
+        systemmap:Q8WjMkerPw98ZkWA7,
+        systemmap:QwlgSr7ukziL6iHsP ;
     rdfs:comment """
         Die Gemeinsame Anmeldestelle Chemikalien ist die zentrale Anlaufstelle für Chemikalien in der Schweiz.
         Sie wird vom Bundesamt für Umwelt (BAFU), dem Bundesamt für Gesundheit (BAG) und dem Staatssekretariat für Wirtschaft (SECO) betrieben.
@@ -159,16 +155,22 @@ systemmap:daccec1f3b64441f98b234bdd8b874dd a schema:Organization ;
         gestito dall'Ufficio federale dell'ambiente (UFAM), dall'Ufficio federale della sanità pubblica (UFSP) e dalla Segreteria di Stato dell'economia (SECO).
         """@it .
 
-systemmap:1f309b91ad564bcb99dd6c8c30bbc0dc a schema:SoftwareApplication ;
-    rdfs:label "Troup'O Herdenmanager"@de ;
-    rdfs:comment """
-        Troup'O ist eine Herdenmanagement-Software für Milchvieh-, Mutterkuh- und Mastbetriebe, die eine zentrale Verwaltung von Zuchtdaten, eine übersichtliche Tierkartei und grafische Analysen bietet.
-        Die dazugehörige Smartphone-App ermöglicht es, Ereignisse wie Reproduktion, Behandlungen und Tierbewegungen in Echtzeit zu dokumentieren und funktioniert auch ohne Netzwerkabdeckung.
-        Dank RFID-Kompatibilität und einer intuitiven Benutzeroberfläche erleichtert Troup'O das Herdenmanagement und steigert die Betriebseffizienz.
-        """@de ;
-    systemmap:operatedBy zefix:505628 .
+systemmap:QhM5kJNFhO8vOAEdK a schema:Organization ;
+    rdfs:label "Europäische Kommission"@de,
+        "European Commission"@en .
 
-systemmap:SYS001 a schema:SoftwareApplication ;
+systemmap:Q6J4iyI6nMI2RCXSY a schema:SoftwareApplication ;
+    rdfs:label "CePa"@de,
+        "CePa"@en,
+        "CePa"@fr,
+        "CePa"@it ;
+    rdfs:comment "CePa ist eine IT-Anwendung für die digitale Verwaltung von Verfahren und Korrespondenz im Rahmen des Pflanzenpassesystems sowie der amtlichen Zertifizierung von Vermehrungsmaterial. Sie optimiert Zertifizierungsabläufe und stellt die Einhaltung pflanzengesundheitlicher Vorschriften sicher. Auf diese Weise wird die Rückverfolgbarkeit und Qualitätskontrolle von Pflanzenmaterial unterstützt."@de,
+        "CePa is an IT application for the digital management of procedures and correspondence within the framework of the plant passport system and the official certification of propagation material. It optimizes certification processes and ensures compliance with plant health regulations. In this way, it supports traceability and quality control of plant material."@en,
+        "CePa est une application informatique pour la gestion numérique des procédures et de la correspondance dans le cadre du système de passeport phytosanitaire ainsi que de la certification officielle du matériel de multiplication. Elle optimise les processus de certification et garantit le respect des réglementations phytosanitaires. De cette manière, elle soutient la traçabilité et le contrôle de la qualité du matériel végétal."@fr,
+        "CePa è un'applicazione IT per la gestione digitale delle procedure e della corrispondenza nell'ambito del sistema del passaporto delle piante e della certificazione ufficiale del materiale di propagazione. Ottimizza i processi di certificazione e garantisce il rispetto delle normative fitosanitarie. In questo modo, supporta la tracciabilità e il controllo della qualità del materiale vegetale."@it ;
+    systemmap:operatedBy systemmap:QFL2DYxeNnVaFsv64 .
+
+systemmap:Q9VcxLSoIIwQjoexY a schema:SoftwareApplication ;
     rdfs:label "Acontrol"@de,
         "Acontrol"@en,
         "Acontrol"@fr,
@@ -194,187 +196,17 @@ systemmap:SYS001 a schema:SoftwareApplication ;
         In questo modo, garantisce un monitoraggio efficiente e il rispetto degli standard agricoli.
         """@it ;
     systemmap:hasLegalBasis LwG:art_165_d ;
-    systemmap:operatedBy systemmap:ORG021 .
+    systemmap:operatedBy systemmap:QcoeXHl4TgJbke1Yf .
 
-systemmap:SYS002 a schema:SoftwareApplication ;
-    rdfs:label "Agate"@de,
-        "Agate"@en,
-        "Agate"@fr,
-        "Agate"@it ;
-    rdfs:comment "Agate ist ein Online-Portal, das den Zugriff auf verschiedene landwirtschaftliche Anwendungen mit nur einem Login ermöglicht. Es erleichtert den Datenaustausch im Agrar- und Ernährungsbereich und erhöht so den Benutzerkomfort. Durch diesen zentralisierten Zugangspunkt werden Verwaltungsprozesse für alle Beteiligten vereinfacht."@de,
-        "Agate is an online portal that allows access to various agricultural applications with just one login. It facilitates data exchange in the agricultural and food sector, thereby increasing user convenience. This centralized access point simplifies administrative processes for all stakeholders."@en,
-        "Agate est un portail en ligne qui permet d'accéder à diverses applications agricoles avec un seul identifiant. Il facilite l'échange de données dans le secteur agricole et alimentaire, augmentant ainsi le confort des utilisateurs. Ce point d'accès centralisé simplifie les processus administratifs pour toutes les parties prenantes."@fr,
-        "Agate è un portale online che consente l'accesso a diverse applicazioni agricole con un solo login. Facilita lo scambio di dati nel settore agricolo e alimentare, aumentando così la comodità per gli utenti. Questo punto di accesso centralizzato semplifica i processi amministrativi per tutte le parti interessate."@it ;
-    systemmap:operatedBy systemmap:ORG214 .
-
-systemmap:SYS003 a schema:SoftwareApplication ;
-    rdfs:label "Agrarpolitisches Informationssystem"@de,
-        "Agricultural Policy Information System"@en,
-        "Système d'information sur la politique agricole"@fr,
-        "Sistema informativo di politica agricola"@it ;
-    rdfs:comment "AGIS fungiert als zentrale Datendrehscheibe, in der die von den Kantonen erhobenen landwirtschaftlichen Daten validiert und zu einem gesamtschweizerischen Datenbestand aggregiert werden. Das System sorgt für Konsistenz und Genauigkeit bei der Erfassung von landwirtschaftlichen Daten. Es unterstützt fundierte Entscheidungsprozesse auf Bundesebene."@de,
-        "AGIS serves as a central data hub where agricultural data collected by the cantons is validated and aggregated into a nationwide dataset. The system ensures consistency and accuracy in the collection of agricultural data. It supports well-founded decision-making processes at the federal level."@en,
-        "SIPA sert de plaque tournante centrale des données, où les données agricoles collectées par les cantons sont validées et agrégées dans un ensemble de données à l'échelle nationale. Le système garantit la cohérence et la précision dans la collecte des données agricoles. Il soutient des processus décisionnels éclairés au niveau fédéral."@fr,
-        "AGIS funge da hub centrale per i dati, dove i dati agricoli raccolti dai cantoni vengono convalidati e aggregati in un insieme di dati a livello nazionale. Il sistema garantisce coerenza e accuratezza nella raccolta dei dati agricoli. Supporta processi decisionali ben fondati a livello federale."@it ;
-    systemmap:abbreviation "AGIS"@de,
-        "AGIS"@en,
-        "SIPA"@fr,
-        "AGIS"@it ;
-    systemmap:hasLegalBasis LwG:art_165_c ;
-    systemmap:operatedBy systemmap:ORG010 .
-
-systemmap:SYS004 a schema:SoftwareApplication ;
-    rdfs:label "Business-Intelligence-System"@de,
-        "Business Intelligence System"@en,
-        "Système de Business Intelligence"@fr,
-        "Sistema di Business Intelligence"@it ;
-    rdfs:comment "ASTAT ist das Business-Intelligence-System des BLW. Es stellt Analyse- und Reporting-Funktionen bereit, um datengestützte Entscheidungen zu ermöglichen. Dadurch wird die Überwachung und Bewertung agrarpolitischer Massnahmen vereinfacht."@de,
-        "ASTAT is the Business Intelligence system of the BLW. It provides analysis and reporting functions to enable data-driven decision-making. This simplifies the monitoring and evaluation of agricultural policy measures."@en,
-        "ASTAT est le système de Business Intelligence de l'OFAG. Il fournit des fonctions d'analyse et de reporting pour permettre une prise de décision basée sur les données. Cela simplifie la surveillance et l'évaluation des mesures de politique agricole."@fr,
-        "ASTAT è il sistema di Business Intelligence dell'UFAG. Fornisce funzioni di analisi e reporting per consentire decisioni basate sui dati. Ciò semplifica il monitoraggio e la valutazione delle misure di politica agricola."@it ;
-    systemmap:abbreviation "ASTAT"@de,
-        "ASTAT"@en,
-        "ASTAT"@fr,
-        "ASTAT"@it ;
-    systemmap:operatedBy systemmap:ORG013 .
-
-systemmap:SYS005 a schema:SoftwareApplication ;
-    rdfs:label "CePa"@de,
-        "CePa"@en,
-        "CePa"@fr,
-        "CePa"@it ;
-    rdfs:comment "CePa ist eine IT-Anwendung für die digitale Verwaltung von Verfahren und Korrespondenz im Rahmen des Pflanzenpassesystems sowie der amtlichen Zertifizierung von Vermehrungsmaterial. Sie optimiert Zertifizierungsabläufe und stellt die Einhaltung pflanzengesundheitlicher Vorschriften sicher. Auf diese Weise wird die Rückverfolgbarkeit und Qualitätskontrolle von Pflanzenmaterial unterstützt."@de,
-        "CePa is an IT application for the digital management of procedures and correspondence within the framework of the plant passport system and the official certification of propagation material. It optimizes certification processes and ensures compliance with plant health regulations. In this way, it supports traceability and quality control of plant material."@en,
-        "CePa est une application informatique pour la gestion numérique des procédures et de la correspondance dans le cadre du système de passeport phytosanitaire ainsi que de la certification officielle du matériel de multiplication. Elle optimise les processus de certification et garantit le respect des réglementations phytosanitaires. De cette manière, elle soutient la traçabilité et le contrôle de la qualité du matériel végétal."@fr,
-        "CePa è un'applicazione IT per la gestione digitale delle procedure e della corrispondenza nell'ambito del sistema del passaporto delle piante e della certificazione ufficiale del materiale di propagazione. Ottimizza i processi di certificazione e garantisce il rispetto delle normative fitosanitarie. In questo modo, supporta la tracciabilità e il controllo della qualità del materiale vegetale."@it ;
-    systemmap:operatedBy systemmap:ORG031 .
-
-systemmap:SYS006 a schema:SoftwareApplication ;
-    rdfs:label "digiFLUX"@de,
-        "digiFLUX"@en,
-        "digiFLUX"@fr,
-        "digiFLUX"@it ;
+systemmap:QBx5yiPz9Nxy2Wnue a schema:SoftwareApplication ;
+    rdfs:label "Mooh Intranet"@de ;
     rdfs:comment """
-        digiFLUX ist eine Webanwendung, die zur Umsetzung der Meldepflicht für den Handel und die Anwendung von Pflanzenschutzmitteln sowie für den Handel mit Nährstoffen entwickelt wurde.
-        Sie ermöglicht den Akteuren eine einheitliche Schnittstelle zur Eingabe aller erforderlichen Angaben.
-        Dadurch wird Transparenz und Einhaltung gesetzlicher Vorschriften im Agrarbereich gewährleistet.
-        """@de,
-        """
-        digiFLUX is a web application developed to implement the reporting obligation for the trade and use of plant protection products as well as for the trade of nutrients.
-        It provides stakeholders with a unified interface for entering all required information.
-        This ensures transparency and compliance with legal regulations in the agricultural sector.
-        """@en,
-        """
-        digiFLUX est une application web développée pour mettre en œuvre l'obligation de déclaration du commerce et de l'utilisation des produits phytosanitaires ainsi que du commerce des nutriments.
-        Elle offre aux acteurs une interface unifiée pour saisir toutes les informations requises.
-        Cela garantit la transparence et le respect des réglementations légales dans le secteur agricole.
-        """@fr,
-        """
-        digiFLUX è un'applicazione web sviluppata per attuare l'obbligo di segnalazione per il commercio e l'uso dei prodotti fitosanitari nonché per il commercio di nutrienti.
-        Fornisce agli operatori un'interfaccia unificata per l'inserimento di tutte le informazioni richieste.
-        Ciò garantisce trasparenza e conformità alle normative legali nel settore agricolo.
-        """@it ;
-    systemmap:hasLegalBasis LwG:art_165_f,
-        LwG:art_165_f_bis ;
-    systemmap:operatedBy systemmap:ORG020 .
+        Intranet-Seite der Mooh Genossenschaft.
+        """@de ;
+    dcat:landingPage <https://intranet.mooh.swiss/> ;
+    systemmap:operatedBy zefix:1256441 .
 
-systemmap:SYS007 a schema:SoftwareApplication ;
-    rdfs:label "eKontingente"@de,
-        "eQuotas"@en,
-        "eContingents"@fr,
-        "eContingenti"@it ;
-    rdfs:comment """  
-        eKontingente ist eine webbasierte Anwendung, mit der allgemeine Einfuhrbewilligungen beantragt, an Auktionen teilgenommen, Einfuhrgesuche eingereicht und zugeteilte Kontingentanteile verwaltet werden können.  
-        Sie ermöglicht eine effiziente Verwaltung von Einfuhrkontingenten. Dadurch wird eine faire und transparente Vergabe von Einfuhrrechten gewährleistet.  
-        """@de,
-        """  
-        eQuotas is a web-based application that allows users to apply for general import permits, participate in auctions, submit import requests, and manage allocated quota shares.  
-        It enables efficient management of import quotas. This ensures a fair and transparent allocation of import rights.  
-        """@en,
-        """  
-        eContingents est une application web permettant de demander des autorisations générales d'importation, de participer à des enchères, de soumettre des demandes d'importation et de gérer les parts de contingents attribuées.  
-        Elle permet une gestion efficace des contingents d'importation. Cela garantit une attribution équitable et transparente des droits d'importation.  
-        """@fr,
-        """  
-        eContingenti è un'applicazione web che consente di richiedere autorizzazioni generali all'importazione, partecipare ad aste, presentare domande di importazione e gestire le quote di contingenti assegnate.  
-        Consente una gestione efficiente dei contingenti di importazione. Ciò garantisce un'assegnazione equa e trasparente dei diritti di importazione.  
-        """@it ;
-    systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/1998/3244_3244_3244>,
-        <https://www.fedlex.admin.ch/eli/cc/2003/791>,
-        <https://www.fedlex.admin.ch/eli/cc/2011/770>,
-        <https://www.fedlex.admin.ch/eli/cc/2016/565> ;
-    systemmap:operatedBy systemmap:ORG040 .
-
-systemmap:SYS008 a schema:SoftwareApplication ;
-    rdfs:label "Meine Agrardatenfreigabe"@de,
-        "My Agricultural Data Release"@en,
-        "Ma libération des données agricoles"@fr,
-        "Il mio rilascio dei dati agricoli"@it ;
-    rdfs:comment """
-        Meine Agrardatenfreigabe vereinfacht den Datenaustausch zwischen Betrieben und Datenempfängern wie zum Beispiel Labelorganisationen.
-        Sie bietet eine Plattform zur Verwaltung von Zugriffsberechtigungen und Datenfreigabevereinbarungen.
-        Damit wird die Zusammenarbeit und Datenweitergabe im Agrarsektor transparenter gestaltet.
-        """@de,
-        """
-        My Agricultural Data Release simplifies data exchange between farms and data recipients such as label organizations.
-        It provides a platform for managing access permissions and data-sharing agreements.
-        This makes collaboration and data transfer in the agricultural sector more transparent.
-        """@en,
-        """
-        Ma libération des données agricoles simplifie l'échange de données entre exploitations agricoles et destinataires de données, tels que les organisations de labels.
-        Elle offre une plateforme pour gérer les autorisations d'accès et les accords de partage de données.
-        Cela rend la collaboration et le transfert de données dans le secteur agricole plus transparents.
-        """@fr,
-        """
-        Il mio rilascio dei dati agricoli semplifica lo scambio di dati tra aziende agricole e destinatari dei dati, come le organizzazioni di etichettatura.
-        Fornisce una piattaforma per gestire i permessi di accesso e gli accordi di condivisione dei dati.
-        Ciò rende più trasparente la collaborazione e il trasferimento dei dati nel settore agricolo.
-        """@it ;
-    systemmap:abbreviation "MAF"@de,
-        "MADR"@en,
-        "MLDA"@fr,
-        "MRDA"@it ;
-    systemmap:operatedBy systemmap:ORG011 .
-
-systemmap:SYS009 a schema:SoftwareApplication ;
-    rdfs:label "Nationale Informationssystem für die Pflanzengenetischen Ressourcen für Ernährung und Landwirtschaft"@de,
-        "National Information System for Plant Genetic Resources for Food and Agriculture"@en,
-        "Système national d'information sur les ressources phytogénétiques pour l'alimentation et l'agriculture"@fr,
-        "Sistema informativo nazionale sulle risorse genetiche vegetali per l'alimentazione e l'agricoltura"@it ;
-    rdfs:comment "Das Nationale Informationssystem für die Pflanzengenetischen Ressourcen für Ernährung und Landwirtschaft (PGREL-NIS) macht Daten des Aktionsplans zur Vielfalt der Kulturpflanzen öffentlich zugänglich. Es bietet einen Überblick und Zugriff auf Informationen zu Pflanzengenetischen Ressourcen. Damit trägt es zur Erhaltung und Förderung pflanzengenetischer Vielfalt bei."@de,
-        "The National Information System for Plant Genetic Resources for Food and Agriculture (PGREL-NIS) provides public access to data from the Action Plan for Crop Diversity. It offers an overview and access to information on plant genetic resources. This contributes to the conservation and promotion of plant genetic diversity."@en,
-        "Le Système national d'information sur les ressources phytogénétiques pour l'alimentation et l'agriculture (PGREL-NIS) donne accès aux données du plan d'action sur la diversité des cultures. Il offre une vue d'ensemble et un accès aux informations sur les ressources phytogénétiques. Cela contribue à la conservation et à la promotion de la diversité génétique des plantes."@fr,
-        "Il Sistema informativo nazionale sulle risorse genetiche vegetali per l'alimentazione e l'agricoltura (PGREL-NIS) rende pubblici i dati del piano d'azione per la diversità delle colture. Fornisce una panoramica e l'accesso alle informazioni sulle risorse genetiche vegetali. Ciò contribuisce alla conservazione e alla promozione della diversità genetica delle piante."@it ;
-    systemmap:abbreviation "PGREL-NIS"@de,
-        "NIS-PGRFA"@en,
-        "SNIRPAA"@fr,
-        "SIN-RGVA"@it ;
-    systemmap:operatedBy systemmap:ORG030 .
-
-systemmap:SYS010 a schema:SoftwareApplication ;
-    rdfs:label "HODUFLU"@de,
-        "HODUFLU"@en,
-        "HODUFLU"@fr,
-        "HODUFLU"@it ;
-    rdfs:comment """
-        HODUFLU ist ein Internetprogramm zur einheitlichen Verwaltung von Hof- und Recyclingdüngerverschiebungen in der Landwirtschaft.
-        Auf dieser Seite finden Sie Zugang zur Anwendung und nützliche Dokumente wie das Benutzerhandbuch für HODUFLU.
-        """@de,
-        """
-        HODUFLU is an internet-based program for the standardized management of farmyard and recycled fertilizer transfers in agriculture.
-        On this page, you will find access to the application and useful documents such as the user manual for HODUFLU.
-        """@en,
-        """
-        HODUFLU est un programme en ligne pour la gestion standardisée des transferts d'engrais de ferme et recyclés en agriculture.
-        Sur cette page, vous trouverez l'accès à l'application ainsi que des documents utiles comme le manuel d'utilisation de HODUFLU.
-        """@fr,
-        """
-        HODUFLU è un programma online per la gestione standardizzata degli spostamenti di fertilizzanti aziendali e riciclati in agricoltura.
-        Su questa pagina troverete l'accesso all'applicazione e documenti utili come il manuale utente di HODUFLU.
-        """@it ;
-    systemmap:operatedBy systemmap:ORG020 .
-
-systemmap:SYS011 a schema:SoftwareApplication ;
+systemmap:QE5DY78J7vgfoiDLj a schema:SoftwareApplication ;
     rdfs:label "Protection Variété"@de,
         "Protection Variété"@en,
         "Protection Variété"@fr,
@@ -399,9 +231,61 @@ systemmap:SYS011 a schema:SoftwareApplication ;
         "ProVar"@en,
         "ProVar"@fr,
         "ProVar"@it ;
-    systemmap:operatedBy systemmap:ORG032 .
+    systemmap:operatedBy systemmap:QfX7h09MplFWwb4LK .
 
-systemmap:SYS012 a schema:SoftwareApplication ;
+systemmap:QGdyOoksCnRRZwi2Q a schema:SoftwareApplication ;
+    rdfs:label "Agate"@de,
+        "Agate"@en,
+        "Agate"@fr,
+        "Agate"@it ;
+    rdfs:comment "Agate ist ein Online-Portal, das den Zugriff auf verschiedene landwirtschaftliche Anwendungen mit nur einem Login ermöglicht. Es erleichtert den Datenaustausch im Agrar- und Ernährungsbereich und erhöht so den Benutzerkomfort. Durch diesen zentralisierten Zugangspunkt werden Verwaltungsprozesse für alle Beteiligten vereinfacht."@de,
+        "Agate is an online portal that allows access to various agricultural applications with just one login. It facilitates data exchange in the agricultural and food sector, thereby increasing user convenience. This centralized access point simplifies administrative processes for all stakeholders."@en,
+        "Agate est un portail en ligne qui permet d'accéder à diverses applications agricoles avec un seul identifiant. Il facilite l'échange de données dans le secteur agricole et alimentaire, augmentant ainsi le confort des utilisateurs. Ce point d'accès centralisé simplifie les processus administratifs pour toutes les parties prenantes."@fr,
+        "Agate è un portale online che consente l'accesso a diverse applicazioni agricole con un solo login. Facilita lo scambio di dati nel settore agricolo e alimentare, aumentando così la comodità per gli utenti. Questo punto di accesso centralizzato semplifica i processi amministrativi per tutte le parti interessate."@it ;
+    systemmap:operatedBy systemmap:QQbNLiw8h9MnSXuyo .
+
+systemmap:QHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
+    rdfs:label "LINDAS"@de,
+        "LINDAS"@en,
+        "LINDAS"@fr,
+        "LINDAS"@it ;
+    rdfs:comment "Mit den Linked Data Services LINDAS können öffentliche Verwaltungen ihre Daten in Form von Knowledge Graphs veröffentlichen und diese über https://lindas.admin.ch zugänglich machen."@de,
+        "Linked Data Services LINDAS allow public administrations to publish their data in the form of Knowledge Graphs and make them accessible via https://lindas.admin.ch"@en,
+        "Avec les services Linked Data LINDAS, les administrations publiques peuvent publier leurs données sous forme de graphe de connaissances et les rendre accessibles via https://lindas.admin.ch."@fr,
+        "Con i Linked Data Services LINDAS, le pubbliche amministrazioni possono pubblicare i loro dati sotto forma di grafi di conoscenza e renderli accessibili attraverso https://lindas.admin.ch."@it ;
+    systemmap:operatedBy systemmap:Q6VSaFePQaMGqU8vD .
+
+systemmap:QMjqlEoVCR9wpTyN1 a schema:SoftwareApplication ;
+    rdfs:label "Acorda"@de,
+        "Acorda"@en,
+        "Acorda"@fr,
+        "Acorda"@it ;
+    rdfs:comment """
+        ACORDA wird von den Kantonen Waadt, Neuenburg, Genf und Jura genutzt.
+        Das System bietet Funktionen wie die Erfassung von Strukturdaten, Berechnung und Auszahlung von Direktzahlungen, Georeferenzierung und Datenaustausch mit Bundessystemen.
+        Zusätzlich verfügt es über spezielle Module für Bereiche wie Bienenzucht, Weinbau und Kontrollen.
+        """@de,
+        """
+        ACORDA is used by the cantons of Vaud, Neuchâtel, Geneva, and Jura.
+        The system offers features such as the collection of structural data, calculation and payment of direct subsidies, georeferencing, and data exchange with federal systems.
+        Additionally, it includes specialized modules for areas such as beekeeping, viticulture, and inspections.
+        """@en,
+        """
+        ACORDA est utilisé par les cantons de Vaud, Neuchâtel, Genève et Jura.
+        Le système offre des fonctionnalités telles que la collecte de données structurelles, le calcul et le paiement des subventions directes, la géoréférencement et l'échange de données avec les systèmes fédéraux.
+        De plus, il comprend des modules spécialisés pour des domaines comme l'apiculture, la viticulture et les contrôles.
+        """@fr,
+        """
+        ACORDA è utilizzato dai cantoni di Vaud, Neuchâtel, Ginevra e Giura.
+        Il sistema offre funzionalità come la raccolta di dati strutturali, il calcolo e il pagamento dei sussidi diretti, la georeferenziazione e lo scambio di dati con i sistemi federali.
+        Inoltre, include moduli specializzati per settori come l'apicoltura, la viticoltura e i controlli.
+        """@it ;
+    systemmap:operatedBy systemmap:Q7eiByZp1HPEEO9Ty,
+        systemmap:QTBfdlLfF2K2AJypD,
+        systemmap:QTg0zUHrhEWXotIau,
+        systemmap:Qqo5ZJtzXw1gg3RYC .
+
+systemmap:QPWOFHR512FuAc25b a schema:SoftwareApplication ;
     rdfs:label "Gesamtlösung EDV Landwirtschaft & Natur"@de,
         "Comprehensive IT Solution for Agriculture & Nature"@en,
         "Solution informatique globale pour l'agriculture et la nature"@fr,
@@ -431,11 +315,73 @@ systemmap:SYS012 a schema:SoftwareApplication ;
         "GELAN"@en,
         "GELAN"@fr,
         "GELAN"@it ;
-    systemmap:operatedBy systemmap:ORG311,
-        systemmap:ORG322,
-        systemmap:ORG336 .
+    systemmap:operatedBy systemmap:QnUxOsahtIQHfvRH9,
+        systemmap:Qp5pkmAETRpXrudck,
+        systemmap:QyTRdNaA9EH12lhiE .
 
-systemmap:SYS013 a schema:SoftwareApplication ;
+systemmap:QU88cJmqj8nBRl2KZ a schema:SoftwareApplication ;
+    rdfs:label "Tierverkehrsdatenbank"@de,
+        "Animal Traffic Database"@en,
+        "Banque de données sur le trafic des animaux"@fr,
+        "Banca dati sul traffico di animali"@it ;
+    rdfs:comment """
+        Die Tierverkehrsdatenbank (TVD) ist ein schweizerisches System zur Registrierung und Nachverfolgung von Nutztieren, wie Rinder, Schweine, Schafe, Ziegen und in Gehege gehaltenes Wild.
+        Dies ist u.a. ein wichtiger Beitrag für die Lebensmittelsicherheit und zu der Eindämmung von Tierseuchen.
+        Dank einem zweckmässigen Erfassungssystem werden in der Datenbank Informationen wie Geburts-, Bewegungs- und Schlachtdaten sowie Halterwechsel erfasst.
+        """@de,
+        """
+        The Animal Traffic Database (TVD) is a Swiss system for the registration and tracking of livestock, such as cattle, pigs, sheep, goats, and game kept in enclosures.
+        This system makes an important contribution to food safety and the containment of animal diseases.
+        Thanks to an efficient recording system, the database collects information such as birth, movement, and slaughter data, as well as ownership changes.
+        """@en,
+        """
+        La banque de données sur le trafic des animaux (BDTA) est un système suisse d’enregistrement et de suivi des animaux de rente, tels que les bovins, les porcs, les ovins, les caprins ou le gibier détenu en enclos.
+        Ce système contribue notamment à la sécurité des denrées alimentaires et à l’enraiement des épizooties.
+        Le système de saisie judicieux permet d’enregistrer des informations relatives à la naissance, aux déplacements et à l’abattage des animaux de rente ou encore aux changements de propriétaires.
+        """@fr,
+        """
+        La Banca dati sul traffico di animali (BDTA) è un sistema svizzero per la registrazione e la tracciabilità di animali da reddito come bovini, suini, ovini, caprini e selvaggina allevata in recinti.
+        Tale sistema contribuisce in modo significativo anche alla sicurezza alimentare e al contenimento delle epizoozie.
+        Grazie a un sistema di registrazione mirato, nella BDTA vengono registrati i dati relativi alla nascita, agli spostamenti, alla macellazione e al cambiamento del detentore.
+        """@it ;
+    systemmap:abbreviation "TVD"@de,
+        "TVD"@en,
+        "BDTA"@fr,
+        "BDTA"@it ;
+    systemmap:operatedBy systemmap:QHObqf1JYpt7KGLFS .
+
+systemmap:QYOd1TkacTh6cr0xP a schema:SoftwareApplication ;
+    rdfs:label "Datenbank Milch"@de,
+        "Milk Database"@en,
+        "Base de données lait"@fr,
+        "Database latte"@it ;
+    rdfs:comment """
+        Die Datenbank Milch (dbmilch.ch) ist eine Webapplikation der TSM Treuhand GmbH.
+        Sie ist die Online-Plattform der Akteure der Schweizer Milchwirtschaft.
+        Die von der Bedag Solutions AG entwickelte Lösung kann von den kantonalen Veterinär- und Landwirtschaftsämtern oder auch anderen Organisationen in Verbindung mit Acontrol genutzt werden.
+        """@de,
+        """
+        The Milk Database (dbmilch.ch) is a web application developed by TSM Treuhand GmbH.
+        It serves as the online platform for stakeholders in the Swiss dairy industry.
+        The solution, developed by Bedag Solutions AG, can be used by cantonal veterinary and agricultural offices or other organizations in connection with Acontrol.
+        """@en,
+        """
+        La base de données lait (dbmilch.ch) est une application web de TSM Treuhand GmbH.
+        Elle est la plateforme en ligne des acteurs de l'industrie laitière suisse.
+        La solution développée par Bedag Solutions AG peut être utilisée par les offices vétérinaires et agricoles cantonaux ou par d'autres organisations en lien avec Acontrol.
+        """@fr,
+        """
+        La database latte (dbmilch.ch) è un'applicazione web di TSM Treuhand GmbH.
+        È la piattaforma online per gli attori dell'industria lattiero-casearia svizzera.
+        La soluzione sviluppata da Bedag Solutions AG può essere utilizzata dagli uffici veterinari e agricoli cantonali o da altre organizzazioni in combinazione con Acontrol.
+        """@it ;
+    systemmap:abbreviation "dbmilch"@de,
+        "dbmilch"@en,
+        "dbmilch"@fr,
+        "dbmilch"@it ;
+    systemmap:operatedBy systemmap:QQ3N7dTc23t2wzXr2 .
+
+systemmap:QZ9LRAuSt2EOvBpqY a schema:SoftwareApplication ;
     rdfs:label "AGRICOLA"@de,
         "AGRICOLA"@en,
         "AGRICOLA"@fr,
@@ -464,50 +410,136 @@ systemmap:SYS013 a schema:SoftwareApplication ;
         Oltre ai pagamenti diretti, supporta anche settori come i miglioramenti strutturali, il diritto fondiario e degli affitti, nonché la protezione della natura.
         Più di 21.000 agricoltori e 1.000 dipendenti amministrativi utilizzano il sistema, che gestisce flussi finanziari di oltre 1 miliardo di franchi svizzeri all'anno.
         """@it ;
-    systemmap:operatedBy systemmap:ORG302,
-        systemmap:ORG306,
-        systemmap:ORG313,
-        systemmap:ORG314,
-        systemmap:ORG318,
-        systemmap:ORG319,
-        systemmap:ORG321,
-        systemmap:ORG323,
-        systemmap:ORG324,
-        systemmap:ORG326,
-        systemmap:ORG330,
-        systemmap:ORG332 .
+    systemmap:operatedBy systemmap:QAz4vX5eiySS4vwuk,
+        systemmap:QDMGFgrGMHxc0eoLM,
+        systemmap:QDp3fNLQF81wWfMDp,
+        systemmap:QEoV4sz2peVmH5wY0,
+        systemmap:QJJVVNtVPxf8nt8VM,
+        systemmap:QNWHuNKVk7ijs7Cbc,
+        systemmap:QTqW9eQHHZNwyCH8i,
+        systemmap:QU0OUwGdItzXRya4Q,
+        systemmap:QU6T65pDC37fWWSHG,
+        systemmap:QUqub30lwOqlTtDN2,
+        systemmap:QVpDMEiTfIVQsNzT8,
+        systemmap:QoVAiCrMPYG2LJxsA .
 
-systemmap:SYS014 a schema:SoftwareApplication ;
-    rdfs:label "Acorda"@de,
-        "Acorda"@en,
-        "Acorda"@fr,
-        "Acorda"@it ;
+systemmap:QeJ36zAhO3AJJix8t a schema:SoftwareApplication ;
+    rdfs:label "Nationale Informationssystem für die Pflanzengenetischen Ressourcen für Ernährung und Landwirtschaft"@de,
+        "National Information System for Plant Genetic Resources for Food and Agriculture"@en,
+        "Système national d'information sur les ressources phytogénétiques pour l'alimentation et l'agriculture"@fr,
+        "Sistema informativo nazionale sulle risorse genetiche vegetali per l'alimentazione e l'agricoltura"@it ;
+    rdfs:comment "Das Nationale Informationssystem für die Pflanzengenetischen Ressourcen für Ernährung und Landwirtschaft (PGREL-NIS) macht Daten des Aktionsplans zur Vielfalt der Kulturpflanzen öffentlich zugänglich. Es bietet einen Überblick und Zugriff auf Informationen zu Pflanzengenetischen Ressourcen. Damit trägt es zur Erhaltung und Förderung pflanzengenetischer Vielfalt bei."@de,
+        "The National Information System for Plant Genetic Resources for Food and Agriculture (PGREL-NIS) provides public access to data from the Action Plan for Crop Diversity. It offers an overview and access to information on plant genetic resources. This contributes to the conservation and promotion of plant genetic diversity."@en,
+        "Le Système national d'information sur les ressources phytogénétiques pour l'alimentation et l'agriculture (PGREL-NIS) donne accès aux données du plan d'action sur la diversité des cultures. Il offre une vue d'ensemble et un accès aux informations sur les ressources phytogénétiques. Cela contribue à la conservation et à la promotion de la diversité génétique des plantes."@fr,
+        "Il Sistema informativo nazionale sulle risorse genetiche vegetali per l'alimentazione e l'agricoltura (PGREL-NIS) rende pubblici i dati del piano d'azione per la diversità delle colture. Fornisce una panoramica e l'accesso alle informazioni sulle risorse genetiche vegetali. Ciò contribuisce alla conservazione e alla promozione della diversità genetica delle piante."@it ;
+    systemmap:abbreviation "PGREL-NIS"@de,
+        "NIS-PGRFA"@en,
+        "SNIRPAA"@fr,
+        "SIN-RGVA"@it ;
+    systemmap:operatedBy systemmap:QMnIieexlpOQHsGvN .
+
+systemmap:Qfv81BPRW0TSnKhGg a schema:SoftwareApplication ;
+    rdfs:label "Troup'O Herdenmanager"@de ;
     rdfs:comment """
-        ACORDA wird von den Kantonen Waadt, Neuenburg, Genf und Jura genutzt.
-        Das System bietet Funktionen wie die Erfassung von Strukturdaten, Berechnung und Auszahlung von Direktzahlungen, Georeferenzierung und Datenaustausch mit Bundessystemen.
-        Zusätzlich verfügt es über spezielle Module für Bereiche wie Bienenzucht, Weinbau und Kontrollen.
+        Troup'O ist eine Herdenmanagement-Software für Milchvieh-, Mutterkuh- und Mastbetriebe, die eine zentrale Verwaltung von Zuchtdaten, eine übersichtliche Tierkartei und grafische Analysen bietet.
+        Die dazugehörige Smartphone-App ermöglicht es, Ereignisse wie Reproduktion, Behandlungen und Tierbewegungen in Echtzeit zu dokumentieren und funktioniert auch ohne Netzwerkabdeckung.
+        Dank RFID-Kompatibilität und einer intuitiven Benutzeroberfläche erleichtert Troup'O das Herdenmanagement und steigert die Betriebseffizienz.
+        """@de ;
+    systemmap:operatedBy zefix:505628 .
+
+systemmap:QhZO092di7cBnOm7F a schema:SoftwareApplication ;
+    rdfs:label "Business-Intelligence-System"@de,
+        "Business Intelligence System"@en,
+        "Système de Business Intelligence"@fr,
+        "Sistema di Business Intelligence"@it ;
+    rdfs:comment "ASTAT ist das Business-Intelligence-System des BLW. Es stellt Analyse- und Reporting-Funktionen bereit, um datengestützte Entscheidungen zu ermöglichen. Dadurch wird die Überwachung und Bewertung agrarpolitischer Massnahmen vereinfacht."@de,
+        "ASTAT is the Business Intelligence system of the BLW. It provides analysis and reporting functions to enable data-driven decision-making. This simplifies the monitoring and evaluation of agricultural policy measures."@en,
+        "ASTAT est le système de Business Intelligence de l'OFAG. Il fournit des fonctions d'analyse et de reporting pour permettre une prise de décision basée sur les données. Cela simplifie la surveillance et l'évaluation des mesures de politique agricole."@fr,
+        "ASTAT è il sistema di Business Intelligence dell'UFAG. Fornisce funzioni di analisi e reporting per consentire decisioni basate sui dati. Ciò semplifica il monitoraggio e la valutazione delle misure di politica agricola."@it ;
+    systemmap:abbreviation "ASTAT"@de,
+        "ASTAT"@en,
+        "ASTAT"@fr,
+        "ASTAT"@it ;
+    systemmap:operatedBy systemmap:QieZtzwlMAxzFY1op .
+
+systemmap:Qhhoiq8azX3SHGL3W a schema:SoftwareApplication ;
+    rdfs:label "Pflanzenschutzmittelverzeichnis"@de,
+        "Plant Protection Products Directory"@en,
+        "Répertoire des produits phytosanitaires"@fr,
+        "Elenco dei prodotti fitosanitari"@it ;
+    rdfs:comment """
+        Die bewilligten Pflanzenschutzmittel werden im Pflanzenschutzmittelverzeichnis aufgelistet.
+        Das Verzeichnis enthält Angaben zur vorgesehenen Anwendung, zu Anwendungseinschränkungen, Aufwandmengen, Gefahrenkennzeichnung und zu Anwendungsauflagen.
         """@de,
         """
-        ACORDA is used by the cantons of Vaud, Neuchâtel, Geneva, and Jura.
-        The system offers features such as the collection of structural data, calculation and payment of direct subsidies, georeferencing, and data exchange with federal systems.
-        Additionally, it includes specialized modules for areas such as beekeeping, viticulture, and inspections.
+        The approved plant protection products are listed in the Plant Protection Products Directory.
+        The directory contains information on intended use, application restrictions, dosage rates, hazard labeling, and application requirements.
         """@en,
         """
-        ACORDA est utilisé par les cantons de Vaud, Neuchâtel, Genève et Jura.
-        Le système offre des fonctionnalités telles que la collecte de données structurelles, le calcul et le paiement des subventions directes, la géoréférencement et l'échange de données avec les systèmes fédéraux.
-        De plus, il comprend des modules spécialisés pour des domaines comme l'apiculture, la viticulture et les contrôles.
+        Les produits phytosanitaires autorisés sont répertoriés dans le répertoire des produits phytosanitaires.
+        Le répertoire contient des informations sur l'utilisation prévue, les restrictions d'application, les doses, l'étiquetage des dangers et les conditions d'application.
         """@fr,
         """
-        ACORDA è utilizzato dai cantoni di Vaud, Neuchâtel, Ginevra e Giura.
-        Il sistema offre funzionalità come la raccolta di dati strutturali, il calcolo e il pagamento dei sussidi diretti, la georeferenziazione e lo scambio di dati con i sistemi federali.
-        Inoltre, include moduli specializzati per settori come l'apicoltura, la viticoltura e i controlli.
+        I prodotti fitosanitari autorizzati sono elencati nell'elenco dei prodotti fitosanitari.
+        L'elenco contiene informazioni sull'uso previsto, sulle restrizioni di applicazione, sulle dosi, sull'etichettatura dei pericoli e sulle condizioni d'uso.
         """@it ;
-    systemmap:operatedBy systemmap:ORG312,
-        systemmap:ORG315,
-        systemmap:ORG317,
-        systemmap:ORG327 .
+    dcat:landingPage <https://www.psm.admin.ch/> ;
+    systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/2010/340> ;
+    systemmap:operatedBy systemmap:QoqmfoevPVgr3d0AA .
 
-systemmap:SYS015 a schema:SoftwareApplication ;
+systemmap:QjCVTMrYaOTygNcqF a schema:SoftwareApplication ;
+    rdfs:label "digiFLUX"@de,
+        "digiFLUX"@en,
+        "digiFLUX"@fr,
+        "digiFLUX"@it ;
+    rdfs:comment """
+        digiFLUX ist eine Webanwendung, die zur Umsetzung der Meldepflicht für den Handel und die Anwendung von Pflanzenschutzmitteln sowie für den Handel mit Nährstoffen entwickelt wurde.
+        Sie ermöglicht den Akteuren eine einheitliche Schnittstelle zur Eingabe aller erforderlichen Angaben.
+        Dadurch wird Transparenz und Einhaltung gesetzlicher Vorschriften im Agrarbereich gewährleistet.
+        """@de,
+        """
+        digiFLUX is a web application developed to implement the reporting obligation for the trade and use of plant protection products as well as for the trade of nutrients.
+        It provides stakeholders with a unified interface for entering all required information.
+        This ensures transparency and compliance with legal regulations in the agricultural sector.
+        """@en,
+        """
+        digiFLUX est une application web développée pour mettre en œuvre l'obligation de déclaration du commerce et de l'utilisation des produits phytosanitaires ainsi que du commerce des nutriments.
+        Elle offre aux acteurs une interface unifiée pour saisir toutes les informations requises.
+        Cela garantit la transparence et le respect des réglementations légales dans le secteur agricole.
+        """@fr,
+        """
+        digiFLUX è un'applicazione web sviluppata per attuare l'obbligo di segnalazione per il commercio e l'uso dei prodotti fitosanitari nonché per il commercio di nutrienti.
+        Fornisce agli operatori un'interfaccia unificata per l'inserimento di tutte le informazioni richieste.
+        Ciò garantisce trasparenza e conformità alle normative legali nel settore agricolo.
+        """@it ;
+    systemmap:hasLegalBasis LwG:art_165_f,
+        LwG:art_165_f_bis ;
+    systemmap:operatedBy systemmap:QyfZhzeyT1CqJU0BP .
+
+systemmap:QlfheulBjlQDwuaIM a schema:SoftwareApplication ;
+    rdfs:label "HODUFLU"@de,
+        "HODUFLU"@en,
+        "HODUFLU"@fr,
+        "HODUFLU"@it ;
+    rdfs:comment """
+        HODUFLU ist ein Internetprogramm zur einheitlichen Verwaltung von Hof- und Recyclingdüngerverschiebungen in der Landwirtschaft.
+        Auf dieser Seite finden Sie Zugang zur Anwendung und nützliche Dokumente wie das Benutzerhandbuch für HODUFLU.
+        """@de,
+        """
+        HODUFLU is an internet-based program for the standardized management of farmyard and recycled fertilizer transfers in agriculture.
+        On this page, you will find access to the application and useful documents such as the user manual for HODUFLU.
+        """@en,
+        """
+        HODUFLU est un programme en ligne pour la gestion standardisée des transferts d'engrais de ferme et recyclés en agriculture.
+        Sur cette page, vous trouverez l'accès à l'application ainsi que des documents utiles comme le manuel d'utilisation de HODUFLU.
+        """@fr,
+        """
+        HODUFLU è un programma online per la gestione standardizzata degli spostamenti di fertilizzanti aziendali e riciclati in agricoltura.
+        Su questa pagina troverete l'accesso all'applicazione e documenti utili come il manuale utente di HODUFLU.
+        """@it ;
+    systemmap:operatedBy systemmap:QyfZhzeyT1CqJU0BP .
+
+systemmap:QmWEQ8lVlDS9ZwPkY a schema:SoftwareApplication ;
     rdfs:label "LAWIS"@de,
         "LAWIS"@en,
         "LAWIS"@fr,
@@ -540,14 +572,56 @@ systemmap:SYS015 a schema:SoftwareApplication ;
         Offre funzionalità GIS e soluzioni mobili per i controlli.
         Il sistema gestisce circa 26.000 aziende agricole e 180.000 particelle e dispone di moduli aggiuntivi per la viticoltura (passaporto dell'uva) e la silvicoltura (portale forestale).
         """@it ;
-    systemmap:operatedBy systemmap:ORG316,
-        systemmap:ORG320,
-        systemmap:ORG325,
-        systemmap:ORG329,
-        systemmap:ORG333,
-        systemmap:ORG335 .
+    systemmap:operatedBy systemmap:Q3wI1gDSK1eZB4l36,
+        systemmap:Q4uUJh3cptyvoesgV,
+        systemmap:QI9jTsa43C0A052y9,
+        systemmap:QRtndZW3LnFXhrQUR,
+        systemmap:QXdYExDt1RcJOS7AY,
+        systemmap:QkaW2ahXWYw9ueeOp .
 
-systemmap:SYS016 a schema:SoftwareApplication ;
+systemmap:QnM0KdtMBmniYOY8f a schema:SoftwareApplication ;
+    rdfs:label "Meine Agrardatenfreigabe"@de,
+        "My Agricultural Data Release"@en,
+        "Ma libération des données agricoles"@fr,
+        "Il mio rilascio dei dati agricoli"@it ;
+    rdfs:comment """
+        Meine Agrardatenfreigabe vereinfacht den Datenaustausch zwischen Betrieben und Datenempfängern wie zum Beispiel Labelorganisationen.
+        Sie bietet eine Plattform zur Verwaltung von Zugriffsberechtigungen und Datenfreigabevereinbarungen.
+        Damit wird die Zusammenarbeit und Datenweitergabe im Agrarsektor transparenter gestaltet.
+        """@de,
+        """
+        My Agricultural Data Release simplifies data exchange between farms and data recipients such as label organizations.
+        It provides a platform for managing access permissions and data-sharing agreements.
+        This makes collaboration and data transfer in the agricultural sector more transparent.
+        """@en,
+        """
+        Ma libération des données agricoles simplifie l'échange de données entre exploitations agricoles et destinataires de données, tels que les organisations de labels.
+        Elle offre une plateforme pour gérer les autorisations d'accès et les accords de partage de données.
+        Cela rend la collaboration et le transfert de données dans le secteur agricole plus transparents.
+        """@fr,
+        """
+        Il mio rilascio dei dati agricoli semplifica lo scambio di dati tra aziende agricole e destinatari dei dati, come le organizzazioni di etichettatura.
+        Fornisce una piattaforma per gestire i permessi di accesso e gli accordi di condivisione dei dati.
+        Ciò rende più trasparente la collaborazione e il trasferimento dei dati nel settore agricolo.
+        """@it ;
+    systemmap:abbreviation "MAF"@de,
+        "MADR"@en,
+        "MLDA"@fr,
+        "MRDA"@it ;
+    systemmap:operatedBy systemmap:QFAwQAwxBcNnaURgO .
+
+systemmap:QpLZd1ojPxF0CvH28 a schema:SoftwareApplication ;
+    rdfs:label "Visualize"@de,
+        "Visualize"@en,
+        "Visualize"@fr,
+        "Visualize"@it ;
+    rdfs:comment "Erstellen Sie Visualisierungen von Datensätzen, welche durch den Linked-Data Dienst (LINDAS) des Bundesarchivs bereitgestellt werden und betten Sie diese in Ihre Webseite ein."@de,
+        "Create and embed visualizations from any dataset provided by the LINDAS Linked Data Service."@en,
+        "Créez et intégrez des visualisations à partir des jeux de données du service LINDAS (Linked Data)."@fr,
+        "Crea ed incorpora visualizzazioni partendo dai dataset forniti dal servizio LINDAS (Linked Data)."@it ;
+    systemmap:operatedBy systemmap:QwlgSr7ukziL6iHsP .
+
+systemmap:QpR2aDraNmiUXz55J a schema:SoftwareApplication ;
     rdfs:label "SAP Wallis"@de,
         "SAP Valais"@en,
         "SAP Valais"@fr,
@@ -572,116 +646,50 @@ systemmap:SYS016 a schema:SoftwareApplication ;
         Un'interfaccia web (ePDir) consente agli utenti esterni di inserire i dati.
         Il sistema è utilizzato dalle aziende agricole, dalle amministrazioni comunali e dalle organizzazioni di controllo ed è impiegato per la gestione dei dati federali e cantonali, dei pagamenti diretti e delle statistiche.
         """@it ;
-    systemmap:operatedBy systemmap:ORG328 .
+    systemmap:operatedBy systemmap:QG5yBV3kE5E5NMM7j .
 
-systemmap:SYS017 a schema:SoftwareApplication ;
-    rdfs:label "Pflanzenschutzmittelverzeichnis"@de,
-        "Plant Protection Products Directory"@en,
-        "Répertoire des produits phytosanitaires"@fr,
-        "Elenco dei prodotti fitosanitari"@it ;
-    rdfs:comment """
-        Die bewilligten Pflanzenschutzmittel werden im Pflanzenschutzmittelverzeichnis aufgelistet.
-        Das Verzeichnis enthält Angaben zur vorgesehenen Anwendung, zu Anwendungseinschränkungen, Aufwandmengen, Gefahrenkennzeichnung und zu Anwendungsauflagen.
+systemmap:QvDlxaJ5YMkuZGH6k a schema:SoftwareApplication ;
+    rdfs:label "Agrarpolitisches Informationssystem"@de,
+        "Agricultural Policy Information System"@en,
+        "Système d'information sur la politique agricole"@fr,
+        "Sistema informativo di politica agricola"@it ;
+    rdfs:comment "AGIS fungiert als zentrale Datendrehscheibe, in der die von den Kantonen erhobenen landwirtschaftlichen Daten validiert und zu einem gesamtschweizerischen Datenbestand aggregiert werden. Das System sorgt für Konsistenz und Genauigkeit bei der Erfassung von landwirtschaftlichen Daten. Es unterstützt fundierte Entscheidungsprozesse auf Bundesebene."@de,
+        "AGIS serves as a central data hub where agricultural data collected by the cantons is validated and aggregated into a nationwide dataset. The system ensures consistency and accuracy in the collection of agricultural data. It supports well-founded decision-making processes at the federal level."@en,
+        "SIPA sert de plaque tournante centrale des données, où les données agricoles collectées par les cantons sont validées et agrégées dans un ensemble de données à l'échelle nationale. Le système garantit la cohérence et la précision dans la collecte des données agricoles. Il soutient des processus décisionnels éclairés au niveau fédéral."@fr,
+        "AGIS funge da hub centrale per i dati, dove i dati agricoli raccolti dai cantoni vengono convalidati e aggregati in un insieme di dati a livello nazionale. Il sistema garantisce coerenza e accuratezza nella raccolta dei dati agricoli. Supporta processi decisionali ben fondati a livello federale."@it ;
+    systemmap:abbreviation "AGIS"@de,
+        "AGIS"@en,
+        "SIPA"@fr,
+        "AGIS"@it ;
+    systemmap:hasLegalBasis LwG:art_165_c ;
+    systemmap:operatedBy systemmap:QE8y4MuFWW5BKqK92 .
+
+systemmap:QywklUB91myTH0cvS a schema:SoftwareApplication ;
+    rdfs:label "eKontingente"@de,
+        "eQuotas"@en,
+        "eContingents"@fr,
+        "eContingenti"@it ;
+    rdfs:comment """  
+        eKontingente ist eine webbasierte Anwendung, mit der allgemeine Einfuhrbewilligungen beantragt, an Auktionen teilgenommen, Einfuhrgesuche eingereicht und zugeteilte Kontingentanteile verwaltet werden können.  
+        Sie ermöglicht eine effiziente Verwaltung von Einfuhrkontingenten. Dadurch wird eine faire und transparente Vergabe von Einfuhrrechten gewährleistet.  
         """@de,
-        """
-        The approved plant protection products are listed in the Plant Protection Products Directory.
-        The directory contains information on intended use, application restrictions, dosage rates, hazard labeling, and application requirements.
+        """  
+        eQuotas is a web-based application that allows users to apply for general import permits, participate in auctions, submit import requests, and manage allocated quota shares.  
+        It enables efficient management of import quotas. This ensures a fair and transparent allocation of import rights.  
         """@en,
-        """
-        Les produits phytosanitaires autorisés sont répertoriés dans le répertoire des produits phytosanitaires.
-        Le répertoire contient des informations sur l'utilisation prévue, les restrictions d'application, les doses, l'étiquetage des dangers et les conditions d'application.
+        """  
+        eContingents est une application web permettant de demander des autorisations générales d'importation, de participer à des enchères, de soumettre des demandes d'importation et de gérer les parts de contingents attribuées.  
+        Elle permet une gestion efficace des contingents d'importation. Cela garantit une attribution équitable et transparente des droits d'importation.  
         """@fr,
-        """
-        I prodotti fitosanitari autorizzati sono elencati nell'elenco dei prodotti fitosanitari.
-        L'elenco contiene informazioni sull'uso previsto, sulle restrizioni di applicazione, sulle dosi, sull'etichettatura dei pericoli e sulle condizioni d'uso.
+        """  
+        eContingenti è un'applicazione web che consente di richiedere autorizzazioni generali all'importazione, partecipare ad aste, presentare domande di importazione e gestire le quote di contingenti assegnate.  
+        Consente una gestione efficiente dei contingenti di importazione. Ciò garantisce un'assegnazione equa e trasparente dei diritti di importazione.  
         """@it ;
-    dcat:landingPage <https://www.psm.admin.ch/> ;
-    systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/2010/340> ;
-    systemmap:operatedBy systemmap:ORG204 .
-
-systemmap:SYS018 a schema:SoftwareApplication ;
-    rdfs:label "LINDAS"@de,
-        "LINDAS"@en,
-        "LINDAS"@fr,
-        "LINDAS"@it ;
-    rdfs:comment "Mit den Linked Data Services LINDAS können öffentliche Verwaltungen ihre Daten in Form von Knowledge Graphs veröffentlichen und diese über https://lindas.admin.ch zugänglich machen."@de,
-        "Linked Data Services LINDAS allow public administrations to publish their data in the form of Knowledge Graphs and make them accessible via https://lindas.admin.ch"@en,
-        "Avec les services Linked Data LINDAS, les administrations publiques peuvent publier leurs données sous forme de graphe de connaissances et les rendre accessibles via https://lindas.admin.ch."@fr,
-        "Con i Linked Data Services LINDAS, le pubbliche amministrazioni possono pubblicare i loro dati sotto forma di grafi di conoscenza e renderli accessibili attraverso https://lindas.admin.ch."@it ;
-    systemmap:operatedBy systemmap:ORG215 .
-
-systemmap:SYS019 a schema:SoftwareApplication ;
-    rdfs:label "Visualize"@de,
-        "Visualize"@en,
-        "Visualize"@fr,
-        "Visualize"@it ;
-    rdfs:comment "Erstellen Sie Visualisierungen von Datensätzen, welche durch den Linked-Data Dienst (LINDAS) des Bundesarchivs bereitgestellt werden und betten Sie diese in Ihre Webseite ein."@de,
-        "Create and embed visualizations from any dataset provided by the LINDAS Linked Data Service."@en,
-        "Créez et intégrez des visualisations à partir des jeux de données du service LINDAS (Linked Data)."@fr,
-        "Crea ed incorpora visualizzazioni partendo dai dataset forniti dal servizio LINDAS (Linked Data)."@it ;
-    systemmap:operatedBy systemmap:4e8ca1ec6eeb4786808a5f71486c4bbf .
-
-systemmap:SYS020 a schema:SoftwareApplication ;
-    rdfs:label "Tierverkehrsdatenbank"@de,
-        "Animal Traffic Database"@en,
-        "Banque de données sur le trafic des animaux"@fr,
-        "Banca dati sul traffico di animali"@it ;
-    rdfs:comment """
-        Die Tierverkehrsdatenbank (TVD) ist ein schweizerisches System zur Registrierung und Nachverfolgung von Nutztieren, wie Rinder, Schweine, Schafe, Ziegen und in Gehege gehaltenes Wild.
-        Dies ist u.a. ein wichtiger Beitrag für die Lebensmittelsicherheit und zu der Eindämmung von Tierseuchen.
-        Dank einem zweckmässigen Erfassungssystem werden in der Datenbank Informationen wie Geburts-, Bewegungs- und Schlachtdaten sowie Halterwechsel erfasst.
-        """@de,
-        """
-        The Animal Traffic Database (TVD) is a Swiss system for the registration and tracking of livestock, such as cattle, pigs, sheep, goats, and game kept in enclosures.
-        This system makes an important contribution to food safety and the containment of animal diseases.
-        Thanks to an efficient recording system, the database collects information such as birth, movement, and slaughter data, as well as ownership changes.
-        """@en,
-        """
-        La banque de données sur le trafic des animaux (BDTA) est un système suisse d’enregistrement et de suivi des animaux de rente, tels que les bovins, les porcs, les ovins, les caprins ou le gibier détenu en enclos.
-        Ce système contribue notamment à la sécurité des denrées alimentaires et à l’enraiement des épizooties.
-        Le système de saisie judicieux permet d’enregistrer des informations relatives à la naissance, aux déplacements et à l’abattage des animaux de rente ou encore aux changements de propriétaires.
-        """@fr,
-        """
-        La Banca dati sul traffico di animali (BDTA) è un sistema svizzero per la registrazione e la tracciabilità di animali da reddito come bovini, suini, ovini, caprini e selvaggina allevata in recinti.
-        Tale sistema contribuisce in modo significativo anche alla sicurezza alimentare e al contenimento delle epizoozie.
-        Grazie a un sistema di registrazione mirato, nella BDTA vengono registrati i dati relativi alla nascita, agli spostamenti, alla macellazione e al cambiamento del detentore.
-        """@it ;
-    systemmap:abbreviation "TVD"@de,
-        "TVD"@en,
-        "BDTA"@fr,
-        "BDTA"@it ;
-    systemmap:operatedBy systemmap:ORG101 .
-
-systemmap:SYS021 a schema:SoftwareApplication ;
-    rdfs:label "Datenbank Milch"@de,
-        "Milk Database"@en,
-        "Base de données lait"@fr,
-        "Database latte"@it ;
-    rdfs:comment """
-        Die Datenbank Milch (dbmilch.ch) ist eine Webapplikation der TSM Treuhand GmbH.
-        Sie ist die Online-Plattform der Akteure der Schweizer Milchwirtschaft.
-        Die von der Bedag Solutions AG entwickelte Lösung kann von den kantonalen Veterinär- und Landwirtschaftsämtern oder auch anderen Organisationen in Verbindung mit Acontrol genutzt werden.
-        """@de,
-        """
-        The Milk Database (dbmilch.ch) is a web application developed by TSM Treuhand GmbH.
-        It serves as the online platform for stakeholders in the Swiss dairy industry.
-        The solution, developed by Bedag Solutions AG, can be used by cantonal veterinary and agricultural offices or other organizations in connection with Acontrol.
-        """@en,
-        """
-        La base de données lait (dbmilch.ch) est une application web de TSM Treuhand GmbH.
-        Elle est la plateforme en ligne des acteurs de l'industrie laitière suisse.
-        La solution développée par Bedag Solutions AG peut être utilisée par les offices vétérinaires et agricoles cantonaux ou par d'autres organisations en lien avec Acontrol.
-        """@fr,
-        """
-        La database latte (dbmilch.ch) è un'applicazione web di TSM Treuhand GmbH.
-        È la piattaforma online per gli attori dell'industria lattiero-casearia svizzera.
-        La soluzione sviluppata da Bedag Solutions AG può essere utilizzata dagli uffici veterinari e agricoli cantonali o da altre organizzazioni in combinazione con Acontrol.
-        """@it ;
-    systemmap:abbreviation "dbmilch"@de,
-        "dbmilch"@en,
-        "dbmilch"@fr,
-        "dbmilch"@it ;
-    systemmap:operatedBy systemmap:ORG100 .
+    systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/1998/3244_3244_3244>,
+        <https://www.fedlex.admin.ch/eli/cc/2003/791>,
+        <https://www.fedlex.admin.ch/eli/cc/2011/770>,
+        <https://www.fedlex.admin.ch/eli/cc/2016/565> ;
+    systemmap:operatedBy systemmap:QRu4rav1Rlm2mUMWr .
 
 systemmap:SYS022 a schema:SoftwareApplication ;
     rdfs:label "ACmobile"@de,
@@ -700,7 +708,7 @@ systemmap:SYS022 a schema:SoftwareApplication ;
         """
         ACmobile è una soluzione mobile indipendente dalla piattaforma per la registrazione elettronica dei risultati delle ispezioni e delle misure.
         """@it ;
-    systemmap:operatedBy systemmap:ORG310 .
+    systemmap:operatedBy systemmap:QmI5VgF2mECWT74i2 .
 
 systemmap:SYS023 a schema:SoftwareApplication ;
     rdfs:label "Barto"@de,
@@ -727,7 +735,7 @@ systemmap:SYS023 a schema:SoftwareApplication ;
         Integra diverse funzioni agronomiche e amministrative e offre agli agricoltori una soluzione centrale per la gestione della loro azienda.
         Barto è gestita da Barto AG e collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
         """@it ;
-    systemmap:operatedBy systemmap:ORG102 .
+    systemmap:operatedBy systemmap:QDetpcQhSMo4IAeAb .
 
 systemmap:SYS024 a schema:SoftwareApplication ;
     rdfs:label "Pflanzensorten-Datenbank"@de,
@@ -742,7 +750,7 @@ systemmap:SYS024 a schema:SoftwareApplication ;
         "PLUTO"@en,
         "PLUTO"@fr,
         "PLUTO"@it ;
-    systemmap:operatedBy systemmap:ORG200 .
+    systemmap:operatedBy systemmap:QBLH2G6TSKaqhqk4n .
 
 systemmap:SYS025 a schema:SoftwareApplication ;
     rdfs:label "Betriebs- und Unternehmensregister"@de,
@@ -774,7 +782,7 @@ systemmap:SYS025 a schema:SoftwareApplication ;
         "REE"@fr,
         "BUR"@it ;
     systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/1993/2253_2253_2253> ;
-    systemmap:operatedBy systemmap:ORG212 .
+    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
 
 systemmap:SYS026 a schema:SoftwareApplication ;
     rdfs:label "e-Deklaration"@de,
@@ -789,7 +797,7 @@ systemmap:SYS026 a schema:SoftwareApplication ;
         "e-dec"@en,
         "e-dec"@fr,
         "e-dec"@it ;
-    systemmap:operatedBy systemmap:ORG210 .
+    systemmap:operatedBy systemmap:QFKPRpdGa5UISiJlx .
 
 systemmap:SYS027 a schema:SoftwareApplication ;
     rdfs:label "UID-Register"@de,
@@ -818,7 +826,7 @@ systemmap:SYS027 a schema:SoftwareApplication ;
         """@it ;
     rdfs:seeAlso <https://www.ech.ch/ech/ech-0108>,
         <https://www.uid.admin.ch/> ;
-    systemmap:operatedBy systemmap:ORG212 .
+    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
 
 systemmap:SYS028 a schema:SoftwareApplication ;
     rdfs:label "Produkteregister Chemikalien"@de,
@@ -847,7 +855,7 @@ systemmap:SYS028 a schema:SoftwareApplication ;
         "CPR"@en,
         "RPC"@fr,
         "RPC"@it ;
-    systemmap:operatedBy systemmap:daccec1f3b64441f98b234bdd8b874dd .
+    systemmap:operatedBy systemmap:QGayLcAMcywbigd3M .
 
 systemmap:SYS029 a schema:SoftwareApplication ;
     rdfs:label "Marktdaten Analyse- und Reporting-System"@de,
@@ -870,7 +878,7 @@ systemmap:SYS029 a schema:SoftwareApplication ;
         "MARS III"@en,
         "MARS III"@fr,
         "MARS III"@it ;
-    systemmap:operatedBy systemmap:ORG012 .
+    systemmap:operatedBy systemmap:QaVyVVsIDkiDMtQq4 .
 
 systemmap:SYS030 a schema:SoftwareApplication ;
     rdfs:label "Geografisches Informationssystem"@de,
@@ -906,7 +914,7 @@ systemmap:SYS030 a schema:SoftwareApplication ;
         "GIS-BLW"@fr,
         "GIS-BLW"@it ;
     systemmap:hasLegalBasis LwG:art_165_e ;
-    systemmap:operatedBy systemmap:ORG010 .
+    systemmap:operatedBy systemmap:QE8y4MuFWW5BKqK92 .
 
 systemmap:SYS031 a schema:SoftwareApplication ;
     rdfs:label "Auswertung/Analyse, Lebensmittelsicherheit, Veterinärwesen, Public Health"@de ;
@@ -916,7 +924,7 @@ systemmap:SYS031 a schema:SoftwareApplication ;
         Ausserdem verfügt ALVPH über viele graphische Funktionen, die eine attraktive Präsentation der Daten erlauben.
         """@de ;
     systemmap:abbreviation "ALVPH"@de ;
-    systemmap:operatedBy systemmap:ORG205 .
+    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
 
 systemmap:SYS032 a schema:SoftwareApplication ;
     rdfs:label "Informationssystem für meldepflichtige Krankheiten"@de,
@@ -941,7 +949,7 @@ systemmap:SYS032 a schema:SoftwareApplication ;
         "InfoSM"@en,
         "InfoSM"@fr,
         "InfoSM"@it ;
-    systemmap:operatedBy systemmap:ORG205 .
+    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
 
 systemmap:SYS033 a schema:SoftwareApplication ;
     rdfs:label "Apinella"@de ;
@@ -949,7 +957,7 @@ systemmap:SYS033 a schema:SoftwareApplication ;
         Software insbesondere für die Früherkennungsprogramm des kleiner Beutenkäfer bei Bienen.
         """@de ;
     dcat:landingPage <https://www.apinella.ch/> ;
-    systemmap:operatedBy systemmap:ORG211 .
+    systemmap:operatedBy systemmap:Q3Rf79NI3Pm1rfOlN .
 
 systemmap:SYS034 a schema:SoftwareApplication ;
     rdfs:label "Traces"@de ;
@@ -957,7 +965,7 @@ systemmap:SYS034 a schema:SoftwareApplication ;
         Alle Personen und Firmen, die am Import- oder Exportprozess für den internationalen Handel von Tieren, Waren tierischen Ursprungs und gewissen Produkten nicht-tierischen Ursprungs beteiligt sind, müssen sich in Traces registrieren lassen.
         Es handelt sich um ein eine Webanwendung der Europäischen Union und unterstützt den grenzüberschreitenden Verkehr von Tieren, Lebensmitteln und tierischen Nebenprodukten.
         """@de ;
-    systemmap:operatedBy systemmap:ORG999 .
+    systemmap:operatedBy systemmap:QhM5kJNFhO8vOAEdK .
 
 systemmap:SYS035 a schema:SoftwareApplication ;
     rdfs:label "eMapis"@de ;
@@ -966,7 +974,7 @@ systemmap:SYS035 a schema:SoftwareApplication ;
         Das System zentralisiert die Erfassung und Verwaltung von Daten sowie Dokumenten, wodurch Doppelerfassungen vermieden werden.
         Mit automatisierten Workflows, einer zentralen Benutzerverwaltung und der Integration von GIS-Daten (sowie zukünftig Betriebsdaten) verbessert eMapis die Transparenz und Effizienz in der Bearbeitung der Finanzhilfefälle.
         """@de ;
-    systemmap:operatedBy systemmap:ORG022 .
+    systemmap:operatedBy systemmap:QG8fSveeGZNcYzoUN .
 
 systemmap:SYS041 a schema:SoftwareApplication ;
     rdfs:label "Zentrale Auswertung von Agrarumweltindikatoren"@de ;
@@ -990,262 +998,13 @@ systemmap:SYS042 a schema:SoftwareApplication ;
         "Un outil de visualisation des informations sur les systèmes informatiques, les données qu'ils contiennent et les organisations qui les exploitent dans le secteur agroalimentaire suisse."@fr,
         "Uno strumento di visualizzazione delle informazioni sui sistemi IT, i dati in essi contenuti e le organizzazioni che li gestiscono nel settore agroalimentare svizzero."@it ;
     dcat:landingPage <https://blw-ofag-ufag.github.io/system-map/> ;
-    systemmap:operatedBy systemmap:ORG011 .
+    systemmap:operatedBy systemmap:QFAwQAwxBcNnaURgO .
 
-systemmap:f4c51499ef7f40e6ac4ec446f508a9bb a schema:SoftwareApplication ;
-    rdfs:label "Mooh Intranet"@de ;
-    rdfs:comment """
-        Intranet-Seite der Mooh Genossenschaft.
-        """@de ;
-    dcat:landingPage <https://intranet.mooh.swiss/> ;
-    systemmap:operatedBy zefix:1256441 .
+systemmap:Q1KtKkrBMoK25AKVA a systemmap:CantonalOrganization ;
+    rdfs:label "Direktzahlungen und Beiträge"@de ;
+    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
 
-systemmap:ORG300 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Aargau"@de,
-        "Canton of Aargau"@en,
-        "Canton d'Argovie"@fr,
-        "Cantone Argovia"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Aargau."@de,
-        "The cantonal administration of Aargau."@en,
-        "L'administration cantonale d'Argovie."@fr,
-        "L'amministrazione cantonale di Argovia."@it ;
-    systemmap:abbreviation "AG" .
-
-systemmap:ORG301 a systemmap:CantonalOrganization ;
-    rdfs:label "Departement Finanzen und Ressourcen"@de ;
-    schema:parentOrganization systemmap:ORG300 .
-
-systemmap:ORG302 a systemmap:CantonalOrganization ;
-    rdfs:label "Landwirtschaft Aargau"@de ;
-    schema:parentOrganization systemmap:ORG301 .
-
-systemmap:ORG303 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Appenzell Ausserrhoden"@de,
-        "Canton of Appenzell Ausserrhoden"@en,
-        "Canton d'Appenzell Rhodes-Extérieures"@fr,
-        "Cantone di Appenzell Esterno"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Appenzell Ausserrhoden."@de,
-        "The cantonal administration of Appenzell Ausserrhoden."@en,
-        "L'administration cantonale d'Appenzell Rhodes-Extérieures."@fr,
-        "L'amministrazione cantonale di Appenzell Esterno."@it ;
-    systemmap:abbreviation "AR" .
-
-systemmap:ORG304 a systemmap:CantonalOrganization ;
-    rdfs:label "Departement Bau und Volkswirtschaft"@de ;
-    schema:parentOrganization systemmap:ORG303 .
-
-systemmap:ORG305 a systemmap:CantonalOrganization ;
-    rdfs:label "Amt für Landwirtschaft"@de ;
-    schema:parentOrganization systemmap:ORG304 ;
-    rdfs:comment """
-        Das Amt für Landwirtschaft des Kantons Appenzell Ausserrhoden unterstützt die landwirtschaftlichen Betriebe in der Region durch Beratung, Fördermassnahmen und administrative Dienstleistungen.
-        Es setzt sich für eine nachhaltige und wirtschaftlich tragfähige Landwirtschaft ein und ist für die Umsetzung agrarpolitischer Vorgaben zuständig.
-        Zudem betreut es Bereiche wie Direktzahlungen, Strukturverbesserungen und Ausbildung in der Landwirtschaft.
-        """@de .
-
-systemmap:ORG306 a systemmap:CantonalOrganization ;
-    rdfs:label "Direktzahlungen und Tierzucht"@de ;
-    schema:parentOrganization systemmap:ORG305 .
-
-systemmap:ORG307 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Appenzell Innerrhoden"@de,
-        "Canton of Appenzell Innerrhoden"@en,
-        "Canton d'Appenzell Rhodes-Intérieures"@fr,
-        "Cantone di Appenzell Interno"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Appenzell Innerrhoden."@de,
-        "The cantonal administration of Appenzell Innerrhoden."@en,
-        "L'administration cantonale d'Appenzell Rhodes-Intérieures."@fr,
-        "L'amministrazione cantonale di Appenzell Interno."@it ;
-    systemmap:abbreviation "AI" .
-
-systemmap:ORG308 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Basel-Landschaft"@de,
-        "Canton of Basel-Landschaft"@en,
-        "Canton de Bâle-Campagne"@fr,
-        "Cantone Basilea Campagna"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Basel-Landschaft."@de,
-        "The cantonal administration of Basel-Landschaft."@en,
-        "L'administration cantonale de Bâle-Campagne."@fr,
-        "L'amministrazione cantonale di Basilea Campagna."@it ;
-    systemmap:abbreviation "BL" .
-
-systemmap:ORG309 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Basel-Stadt"@de,
-        "Canton of Basel-Stadt"@en,
-        "Canton de Bâle-Ville"@fr,
-        "Cantone Basilea Città"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Basel-Stadt."@de,
-        "The cantonal administration of Basel-Stadt."@en,
-        "L'administration cantonale de Bâle-Ville."@fr,
-        "L'amministrazione cantonale di Basilea Città."@it ;
-    systemmap:abbreviation "BS" .
-
-systemmap:ORG310 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Bern"@de,
-        "Canton of Bern"@en,
-        "Canton de Berne"@fr,
-        "Cantone di Berna"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Bern."@de,
-        "The cantonal administration of Bern."@en,
-        "L'administration cantonale de Berne."@fr,
-        "L'amministrazione cantonale di Berna."@it ;
-    systemmap:abbreviation "BE" .
-
-systemmap:ORG311 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Freiburg"@de,
-        "Canton of Fribourg"@en,
-        "Canton de Fribourg"@fr,
-        "Cantone di Friburgo"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Freiburg."@de,
-        "The cantonal administration of Fribourg."@en,
-        "L'administration cantonale de Fribourg."@fr,
-        "L'amministrazione cantonale di Friburgo."@it ;
-    systemmap:abbreviation "FR" .
-
-systemmap:ORG312 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Genf"@de,
-        "Canton of Geneva"@en,
-        "Canton de Genève"@fr,
-        "Cantone di Ginevra"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Genf."@de,
-        "The cantonal administration of Geneva."@en,
-        "L'administration cantonale de Genève."@fr,
-        "L'amministrazione cantonale di Ginevra."@it ;
-    systemmap:abbreviation "GE" .
-
-systemmap:ORG313 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Glarus"@de,
-        "Canton of Glarus"@en,
-        "Canton de Glaris"@fr,
-        "Cantone di Glarus"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Glarus."@de,
-        "The cantonal administration of Glarus."@en,
-        "L'administration cantonale de Glaris."@fr,
-        "L'amministrazione cantonale di Glarus."@it ;
-    systemmap:abbreviation "GL" .
-
-systemmap:ORG314 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Graubünden"@de,
-        "Canton of Graubünden"@en,
-        "Canton des Grisons"@fr,
-        "Cantone dei Grigioni"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Graubünden."@de,
-        "The cantonal administration of Graubünden."@en,
-        "L'administration cantonale des Grisons."@fr,
-        "L'amministrazione cantonale dei Grigioni."@it ;
-    systemmap:abbreviation "GR" .
-
-systemmap:ORG315 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Jura"@de,
-        "Canton of Jura"@en,
-        "Canton du Jura"@fr,
-        "Cantone del Giura"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Jura."@de,
-        "The cantonal administration of Jura."@en,
-        "L'administration cantonale du Jura."@fr,
-        "L'amministrazione cantonale del Giura."@it ;
-    systemmap:abbreviation "JU" .
-
-systemmap:ORG316 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Luzern"@de,
-        "Canton of Lucerne"@en,
-        "Canton de Lucerne"@fr,
-        "Cantone di Lucerna"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Luzern."@de,
-        "The cantonal administration of Lucerne."@en,
-        "L'administration cantonale de Lucerne."@fr,
-        "L'amministrazione cantonale di Lucerna."@it ;
-    systemmap:abbreviation "LU" .
-
-systemmap:ORG317 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Neuenburg"@de,
-        "Canton of Neuchâtel"@en,
-        "Canton de Neuchâtel"@fr,
-        "Cantone di Neuchâtel"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Neuenburg."@de,
-        "The cantonal administration of Neuchâtel."@en,
-        "L'administration cantonale de Neuchâtel."@fr,
-        "L'amministrazione cantonale di Neuchâtel."@it ;
-    systemmap:abbreviation "NE" .
-
-systemmap:ORG318 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Nidwalden"@de,
-        "Canton of Nidwalden"@en,
-        "Canton de Nidwald"@fr,
-        "Cantone di Nidvaldo"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Nidwalden."@de,
-        "The cantonal administration of Nidwalden."@en,
-        "L'administration cantonale de Nidwald."@fr,
-        "L'amministrazione cantonale di Nidvaldo."@it ;
-    systemmap:abbreviation "NW" .
-
-systemmap:ORG319 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Obwalden"@de,
-        "Canton of Obwalden"@en,
-        "Canton d'Obwald"@fr,
-        "Cantone di Obvaldo"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Obwalden."@de,
-        "The cantonal administration of Obwalden."@en,
-        "L'administration cantonale d'Obwald."@fr,
-        "L'amministrazione cantonale di Obvaldo."@it ;
-    systemmap:abbreviation "OW" .
-
-systemmap:ORG320 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Schaffhausen"@de,
-        "Canton of Schaffhausen"@en,
-        "Canton de Schaffhouse"@fr,
-        "Cantone di Schaffhausen"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Schaffhausen."@de,
-        "The cantonal administration of Schaffhausen."@en,
-        "L'administration cantonale de Schaffhouse."@fr,
-        "L'amministrazione cantonale di Schaffhausen."@it ;
-    systemmap:abbreviation "SH" .
-
-systemmap:ORG321 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Schwyz"@de,
-        "Canton of Schwyz"@en,
-        "Canton de Schwytz"@fr,
-        "Cantone di Svitto"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Schwyz."@de,
-        "The cantonal administration of Schwyz."@en,
-        "L'administration cantonale de Schwytz."@fr,
-        "L'amministrazione cantonale di Svitto."@it ;
-    systemmap:abbreviation "SZ" .
-
-systemmap:ORG322 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Solothurn"@de,
-        "Canton of Solothurn"@en,
-        "Canton de Soleure"@fr,
-        "Cantone di Soletta"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Solothurn."@de,
-        "The cantonal administration of Solothurn."@en,
-        "L'administration cantonale de Soleure."@fr,
-        "L'amministrazione cantonale di Soletta."@it ;
-    systemmap:abbreviation "SO" .
-
-systemmap:ORG323 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton St. Gallen"@de,
-        "Canton of St. Gallen"@en,
-        "Canton de Saint-Gall"@fr,
-        "Cantone di San Gallo"@it ;
-    rdfs:comment "Die kantonale Verwaltung von St. Gallen."@de,
-        "The cantonal administration of St. Gallen."@en,
-        "L'administration cantonale de Saint-Gall."@fr,
-        "L'amministrazione cantonale di San Gallo."@it ;
-    systemmap:abbreviation "SG" .
-
-systemmap:ORG324 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Tessin"@de,
-        "Canton of Ticino"@en,
-        "Canton du Tessin"@fr,
-        "Cantone Ticino"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Tessin."@de,
-        "The cantonal administration of Ticino."@en,
-        "L'administration cantonale du Tessin."@fr,
-        "L'amministrazione cantonale di Ticino."@it ;
-    systemmap:abbreviation "TI" .
-
-systemmap:ORG325 a systemmap:CantonalOrganization ;
+systemmap:Q3wI1gDSK1eZB4l36 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Thurgau"@de,
         "Canton of Thurgau"@en,
         "Canton de Thurgovie"@fr,
@@ -1256,18 +1015,16 @@ systemmap:ORG325 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Turgovia."@it ;
     systemmap:abbreviation "TG" .
 
-systemmap:ORG326 a systemmap:CantonalOrganization ;
-    rdfs:label "Kanton Uri"@de,
-        "Canton of Uri"@en,
-        "Canton d'Uri"@fr,
-        "Cantone di Uri"@it ;
-    rdfs:comment "Die kantonale Verwaltung von Uri."@de,
-        "The cantonal administration of Uri."@en,
-        "L'administration cantonale d'Uri."@fr,
-        "L'amministrazione cantonale di Uri."@it ;
-    systemmap:abbreviation "UR" .
+systemmap:Q4uUJh3cptyvoesgV a systemmap:CantonalOrganization ;
+    rdfs:label "Landwirtschaft"@de ;
+    schema:parentOrganization systemmap:QtD442ueFttFeM59d .
 
-systemmap:ORG327 a systemmap:CantonalOrganization ;
+systemmap:Q5PQMffJ6VPs6c4Eg a systemmap:CantonalOrganization ;
+    rdfs:label "Land- und Forstwirtschaftsdepartement"@de ;
+    schema:parentOrganization systemmap:QP3XCaL5d9GyKtg5H ;
+    systemmap:abbreviation "LFD"@de .
+
+systemmap:Q7eiByZp1HPEEO9Ty a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Waadt"@de,
         "Canton of Vaud"@en,
         "Canton de Vaud"@fr,
@@ -1278,7 +1035,55 @@ systemmap:ORG327 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Vaud."@it ;
     systemmap:abbreviation "VD" .
 
-systemmap:ORG328 a systemmap:CantonalOrganization ;
+systemmap:QAz4vX5eiySS4vwuk a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Obwalden"@de,
+        "Canton of Obwalden"@en,
+        "Canton d'Obwald"@fr,
+        "Cantone di Obvaldo"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Obwalden."@de,
+        "The cantonal administration of Obwalden."@en,
+        "L'administration cantonale d'Obwald."@fr,
+        "L'amministrazione cantonale di Obvaldo."@it ;
+    systemmap:abbreviation "OW" .
+
+systemmap:QCC189KCYnABsbian a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Appenzell Ausserrhoden"@de,
+        "Canton of Appenzell Ausserrhoden"@en,
+        "Canton d'Appenzell Rhodes-Extérieures"@fr,
+        "Cantone di Appenzell Esterno"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Appenzell Ausserrhoden."@de,
+        "The cantonal administration of Appenzell Ausserrhoden."@en,
+        "L'administration cantonale d'Appenzell Rhodes-Extérieures."@fr,
+        "L'amministrazione cantonale di Appenzell Esterno."@it ;
+    systemmap:abbreviation "AR" .
+
+systemmap:QDMGFgrGMHxc0eoLM a systemmap:CantonalOrganization ;
+    rdfs:label "Landwirtschaft Aargau"@de ;
+    schema:parentOrganization systemmap:QXgifgY4eK6N4W9jr .
+
+systemmap:QDp3fNLQF81wWfMDp a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Tessin"@de,
+        "Canton of Ticino"@en,
+        "Canton du Tessin"@fr,
+        "Cantone Ticino"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Tessin."@de,
+        "The cantonal administration of Ticino."@en,
+        "L'administration cantonale du Tessin."@fr,
+        "L'amministrazione cantonale di Ticino."@it ;
+    systemmap:abbreviation "TI" .
+
+systemmap:QEoV4sz2peVmH5wY0 a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Schwyz"@de,
+        "Canton of Schwyz"@en,
+        "Canton de Schwytz"@fr,
+        "Cantone di Svitto"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Schwyz."@de,
+        "The cantonal administration of Schwyz."@en,
+        "L'administration cantonale de Schwytz."@fr,
+        "L'amministrazione cantonale di Svitto."@it ;
+    systemmap:abbreviation "SZ" .
+
+systemmap:QG5yBV3kE5E5NMM7j a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Wallis"@de,
         "Canton of Valais"@en,
         "Canton du Valais"@fr,
@@ -1289,7 +1094,75 @@ systemmap:ORG328 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale del Vallese."@it ;
     systemmap:abbreviation "VS" .
 
-systemmap:ORG329 a systemmap:CantonalOrganization ;
+systemmap:QGkAVZIrJPw0HqHLs a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Aargau"@de,
+        "Canton of Aargau"@en,
+        "Canton d'Argovie"@fr,
+        "Cantone Argovia"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Aargau."@de,
+        "The cantonal administration of Aargau."@en,
+        "L'administration cantonale d'Argovie."@fr,
+        "L'amministrazione cantonale di Argovia."@it ;
+    systemmap:abbreviation "AG" .
+
+systemmap:QI9jTsa43C0A052y9 a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Schaffhausen"@de,
+        "Canton of Schaffhausen"@en,
+        "Canton de Schaffhouse"@fr,
+        "Cantone di Schaffhausen"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Schaffhausen."@de,
+        "The cantonal administration of Schaffhausen."@en,
+        "L'administration cantonale de Schaffhouse."@fr,
+        "L'amministrazione cantonale di Schaffhausen."@it ;
+    systemmap:abbreviation "SH" .
+
+systemmap:QJJVVNtVPxf8nt8VM a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Uri"@de,
+        "Canton of Uri"@en,
+        "Canton d'Uri"@fr,
+        "Cantone di Uri"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Uri."@de,
+        "The cantonal administration of Uri."@en,
+        "L'administration cantonale d'Uri."@fr,
+        "L'amministrazione cantonale di Uri."@it ;
+    systemmap:abbreviation "UR" .
+
+systemmap:QKUAYpzZ9E3EItXRv a systemmap:CantonalOrganization ;
+    rdfs:label "Koordinationsstelle für das Adress- und Betriebsregister"@de ;
+    schema:parentOrganization systemmap:QSTWtmHeK8GuPkomQ .
+
+systemmap:QNR9jjxZTYmU0qC1N a systemmap:CantonalOrganization ;
+    rdfs:label "Amt für Landwirtschaft"@de ;
+    schema:parentOrganization systemmap:QX3LDErwHN1dlwmGS ;
+    rdfs:comment """
+        Das Amt für Landwirtschaft des Kantons Appenzell Ausserrhoden unterstützt die landwirtschaftlichen Betriebe in der Region durch Beratung, Fördermassnahmen und administrative Dienstleistungen.
+        Es setzt sich für eine nachhaltige und wirtschaftlich tragfähige Landwirtschaft ein und ist für die Umsetzung agrarpolitischer Vorgaben zuständig.
+        Zudem betreut es Bereiche wie Direktzahlungen, Strukturverbesserungen und Ausbildung in der Landwirtschaft.
+        """@de .
+
+systemmap:QNWHuNKVk7ijs7Cbc a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Graubünden"@de,
+        "Canton of Graubünden"@en,
+        "Canton des Grisons"@fr,
+        "Cantone dei Grigioni"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Graubünden."@de,
+        "The cantonal administration of Graubünden."@en,
+        "L'administration cantonale des Grisons."@fr,
+        "L'amministrazione cantonale dei Grigioni."@it ;
+    systemmap:abbreviation "GR" .
+
+systemmap:QP3XCaL5d9GyKtg5H a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Appenzell Innerrhoden"@de,
+        "Canton of Appenzell Innerrhoden"@en,
+        "Canton d'Appenzell Rhodes-Intérieures"@fr,
+        "Cantone di Appenzell Interno"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Appenzell Innerrhoden."@de,
+        "The cantonal administration of Appenzell Innerrhoden."@en,
+        "L'administration cantonale d'Appenzell Rhodes-Intérieures."@fr,
+        "L'amministrazione cantonale di Appenzell Interno."@it ;
+    systemmap:abbreviation "AI" .
+
+systemmap:QRtndZW3LnFXhrQUR a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Zug"@de,
         "Canton of Zug"@en,
         "Canton de Zoug"@fr,
@@ -1300,7 +1173,33 @@ systemmap:ORG329 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Zugo."@it ;
     systemmap:abbreviation "ZG" .
 
-systemmap:ORG330 a systemmap:CantonalOrganization ;
+systemmap:QSTWtmHeK8GuPkomQ a systemmap:CantonalOrganization ;
+    rdfs:label "Abteilung Direktzahlungen"@de ;
+    schema:parentOrganization systemmap:QnUxOsahtIQHfvRH9 .
+
+systemmap:QTBfdlLfF2K2AJypD a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Jura"@de,
+        "Canton of Jura"@en,
+        "Canton du Jura"@fr,
+        "Cantone del Giura"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Jura."@de,
+        "The cantonal administration of Jura."@en,
+        "L'administration cantonale du Jura."@fr,
+        "L'amministrazione cantonale del Giura."@it ;
+    systemmap:abbreviation "JU" .
+
+systemmap:QTg0zUHrhEWXotIau a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Neuenburg"@de,
+        "Canton of Neuchâtel"@en,
+        "Canton de Neuchâtel"@fr,
+        "Cantone di Neuchâtel"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Neuenburg."@de,
+        "The cantonal administration of Neuchâtel."@en,
+        "L'administration cantonale de Neuchâtel."@fr,
+        "L'amministrazione cantonale di Neuchâtel."@it ;
+    systemmap:abbreviation "NE" .
+
+systemmap:QTqW9eQHHZNwyCH8i a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Zürich"@de,
         "Canton of Zurich"@en,
         "Canton de Zurich"@fr,
@@ -1311,71 +1210,188 @@ systemmap:ORG330 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Zurigo."@it ;
     systemmap:abbreviation "ZH" .
 
-systemmap:ORG331 a systemmap:CantonalOrganization ;
-    rdfs:label "Land- und Forstwirtschaftsdepartement"@de ;
-    schema:parentOrganization systemmap:ORG307 ;
-    systemmap:abbreviation "LFD"@de .
+systemmap:QU0OUwGdItzXRya4Q a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Nidwalden"@de,
+        "Canton of Nidwalden"@en,
+        "Canton de Nidwald"@fr,
+        "Cantone di Nidvaldo"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Nidwalden."@de,
+        "The cantonal administration of Nidwalden."@en,
+        "L'administration cantonale de Nidwald."@fr,
+        "L'amministrazione cantonale di Nidvaldo."@it ;
+    systemmap:abbreviation "NW" .
 
-systemmap:ORG332 a systemmap:CantonalOrganization ;
+systemmap:QU6T65pDC37fWWSHG a systemmap:CantonalOrganization ;
     rdfs:label "Landwirtschaftsamt"@de ;
-    schema:parentOrganization systemmap:ORG331 .
+    schema:parentOrganization systemmap:Q5PQMffJ6VPs6c4Eg .
 
-systemmap:ORG333 a systemmap:CantonalOrganization ;
+systemmap:QUqub30lwOqlTtDN2 a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton St. Gallen"@de,
+        "Canton of St. Gallen"@en,
+        "Canton de Saint-Gall"@fr,
+        "Cantone di San Gallo"@it ;
+    rdfs:comment "Die kantonale Verwaltung von St. Gallen."@de,
+        "The cantonal administration of St. Gallen."@en,
+        "L'administration cantonale de Saint-Gall."@fr,
+        "L'amministrazione cantonale di San Gallo."@it ;
+    systemmap:abbreviation "SG" .
+
+systemmap:QVpDMEiTfIVQsNzT8 a systemmap:CantonalOrganization ;
+    rdfs:label "Direktzahlungen und Tierzucht"@de ;
+    schema:parentOrganization systemmap:QNR9jjxZTYmU0qC1N .
+
+systemmap:QVziLYQkMiRWMaajH a systemmap:CantonalOrganization ;
+    rdfs:label "Zentrale Dienste"@de ;
+    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+
+systemmap:QX3LDErwHN1dlwmGS a systemmap:CantonalOrganization ;
+    rdfs:label "Departement Bau und Volkswirtschaft"@de ;
+    schema:parentOrganization systemmap:QCC189KCYnABsbian .
+
+systemmap:QXdYExDt1RcJOS7AY a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Luzern"@de,
+        "Canton of Lucerne"@en,
+        "Canton de Lucerne"@fr,
+        "Cantone di Lucerna"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Luzern."@de,
+        "The cantonal administration of Lucerne."@en,
+        "L'administration cantonale de Lucerne."@fr,
+        "L'amministrazione cantonale di Lucerna."@it ;
+    systemmap:abbreviation "LU" .
+
+systemmap:QXgifgY4eK6N4W9jr a systemmap:CantonalOrganization ;
+    rdfs:label "Departement Finanzen und Ressourcen"@de ;
+    schema:parentOrganization systemmap:QGkAVZIrJPw0HqHLs .
+
+systemmap:QfCWpkO67ty1HLzmK a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Basel-Stadt"@de,
+        "Canton of Basel-Stadt"@en,
+        "Canton de Bâle-Ville"@fr,
+        "Cantone Basilea Città"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Basel-Stadt."@de,
+        "The cantonal administration of Basel-Stadt."@en,
+        "L'administration cantonale de Bâle-Ville."@fr,
+        "L'amministrazione cantonale di Basilea Città."@it ;
+    systemmap:abbreviation "BS" .
+
+systemmap:QjozrVSzUVos5diiL a systemmap:CantonalOrganization ;
+    rdfs:label "Landwirtschaftliches Zentrum Liebegg"@de ;
+    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+
+systemmap:QkaW2ahXWYw9ueeOp a systemmap:CantonalOrganization ;
     rdfs:label "Ebenrain-Zentrum für Landwirtschaft, Natur und Ernährung"@de ;
-    schema:parentOrganization systemmap:ORG308 ;
+    schema:parentOrganization systemmap:QzHOtHCVjJXECjyDj ;
     rdfs:comment "Das Ebenrain-Zentrum für Landwirtschaft, Natur und Ernährung mit Sitz in Sissach übernimmt die Aufgaben des Kantons zugunsten von Landwirtschaft, Natur und Ernährung. Der Ebenrain führt eine landwirtschaftliche Schule zur Ausbildung der Landwirte und Landwirtinnen, die Brücke Ebenrain sowie einen Kursgarten für die praktische Bildungsarbeit. Mit Kursen und Beratung sorgt er dafür, dass die Landwirtinnen und Landwirte fachlich fit für die Zukunft sind. Er fördert eine gesunde und ausgewogene Ernährung in der Gemeinschaftsgastronomie und in der breiten Bevölkerung."@de .
 
-systemmap:ORG334 a systemmap:CantonalOrganization ;
-    rdfs:label "Amt für Umwelt und Energie"@de ;
-    schema:parentOrganization systemmap:ORG309 .
+systemmap:Qlsq3Et7cyDrThfMW a systemmap:CantonalOrganization ;
+    rdfs:label "Departement Gesundheit und Soziales"@de ;
+    schema:parentOrganization systemmap:QGkAVZIrJPw0HqHLs .
 
-systemmap:ORG335 a systemmap:CantonalOrganization ;
-    rdfs:label "Landwirtschaft"@de ;
-    schema:parentOrganization systemmap:ORG334 .
+systemmap:QmI5VgF2mECWT74i2 a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Bern"@de,
+        "Canton of Bern"@en,
+        "Canton de Berne"@fr,
+        "Cantone di Berna"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Bern."@de,
+        "The cantonal administration of Bern."@en,
+        "L'administration cantonale de Berne."@fr,
+        "L'amministrazione cantonale di Berna."@it ;
+    systemmap:abbreviation "BE" .
 
-systemmap:ORG336 a systemmap:CantonalOrganization ;
+systemmap:QnUxOsahtIQHfvRH9 a systemmap:CantonalOrganization ;
     rdfs:label "Amt für Landwirtschaft und Natur"@de ;
-    schema:parentOrganization systemmap:ORG310 ;
+    schema:parentOrganization systemmap:QmI5VgF2mECWT74i2 ;
     systemmap:abbreviation "LANAT"@de .
 
-systemmap:ORG337 a systemmap:CantonalOrganization ;
-    rdfs:label "Abteilung Direktzahlungen"@de ;
-    schema:parentOrganization systemmap:ORG336 .
+systemmap:QoVAiCrMPYG2LJxsA a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Glarus"@de,
+        "Canton of Glarus"@en,
+        "Canton de Glaris"@fr,
+        "Cantone di Glarus"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Glarus."@de,
+        "The cantonal administration of Glarus."@en,
+        "L'administration cantonale de Glaris."@fr,
+        "L'amministrazione cantonale di Glarus."@it ;
+    systemmap:abbreviation "GL" .
 
-systemmap:ORG338 a systemmap:CantonalOrganization ;
-    rdfs:label "Koordinationsstelle für das Adress- und Betriebsregister"@de ;
-    schema:parentOrganization systemmap:ORG337 .
+systemmap:Qp5pkmAETRpXrudck a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Freiburg"@de,
+        "Canton of Fribourg"@en,
+        "Canton de Fribourg"@fr,
+        "Cantone di Friburgo"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Freiburg."@de,
+        "The cantonal administration of Fribourg."@en,
+        "L'administration cantonale de Fribourg."@fr,
+        "L'amministrazione cantonale di Friburgo."@it ;
+    systemmap:abbreviation "FR" .
 
-systemmap:ORG339 a systemmap:CantonalOrganization ;
-    rdfs:label "Departement Gesundheit und Soziales"@de ;
-    schema:parentOrganization systemmap:ORG300 .
-
-systemmap:ORG341 a systemmap:CantonalOrganization ;
+systemmap:QpJ9AAjLlCAkFBhVU a systemmap:CantonalOrganization ;
     rdfs:label "Strategie und Planung"@de ;
-    schema:parentOrganization systemmap:ORG302 .
+    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
 
-systemmap:ORG342 a systemmap:CantonalOrganization ;
-    rdfs:label "Zentrale Dienste"@de ;
-    schema:parentOrganization systemmap:ORG302 .
+systemmap:Qqo5ZJtzXw1gg3RYC a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Genf"@de,
+        "Canton of Geneva"@en,
+        "Canton de Genève"@fr,
+        "Cantone di Ginevra"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Genf."@de,
+        "The cantonal administration of Geneva."@en,
+        "L'administration cantonale de Genève."@fr,
+        "L'amministrazione cantonale di Ginevra."@it ;
+    systemmap:abbreviation "GE" .
 
-systemmap:ORG343 a systemmap:CantonalOrganization ;
-    rdfs:label "Landwirtschaftliches Zentrum Liebegg"@de ;
-    schema:parentOrganization systemmap:ORG302 .
+systemmap:QtD442ueFttFeM59d a systemmap:CantonalOrganization ;
+    rdfs:label "Amt für Umwelt und Energie"@de ;
+    schema:parentOrganization systemmap:QfCWpkO67ty1HLzmK .
 
-systemmap:ORG344 a systemmap:CantonalOrganization ;
-    rdfs:label "Direktzahlungen und Beiträge"@de ;
-    schema:parentOrganization systemmap:ORG302 .
-
-systemmap:ORG345 a systemmap:CantonalOrganization ;
+systemmap:QxYQ8wqWnYpmVR7FT a systemmap:CantonalOrganization ;
     rdfs:label "Strukturverbesserungen und Raumnutzung"@de ;
-    schema:parentOrganization systemmap:ORG302 .
+    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
 
-systemmap:ORG340 a systemmap:CantonalVeterinaryService ;
+systemmap:QyTRdNaA9EH12lhiE a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Solothurn"@de,
+        "Canton of Solothurn"@en,
+        "Canton de Soleure"@fr,
+        "Cantone di Soletta"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Solothurn."@de,
+        "The cantonal administration of Solothurn."@en,
+        "L'administration cantonale de Soleure."@fr,
+        "L'amministrazione cantonale di Soletta."@it ;
+    systemmap:abbreviation "SO" .
+
+systemmap:QzHOtHCVjJXECjyDj a systemmap:CantonalOrganization ;
+    rdfs:label "Kanton Basel-Landschaft"@de,
+        "Canton of Basel-Landschaft"@en,
+        "Canton de Bâle-Campagne"@fr,
+        "Cantone Basilea Campagna"@it ;
+    rdfs:comment "Die kantonale Verwaltung von Basel-Landschaft."@de,
+        "The cantonal administration of Basel-Landschaft."@en,
+        "L'administration cantonale de Bâle-Campagne."@fr,
+        "L'amministrazione cantonale di Basilea Campagna."@it ;
+    systemmap:abbreviation "BL" .
+
+systemmap:QY0h92GbLVkapqnQt a systemmap:CantonalVeterinaryService ;
     rdfs:label "Kantonaler Veterinärdienst Aargau"@de ;
-    schema:parentOrganization systemmap:ORG339 ;
+    schema:parentOrganization systemmap:Qlsq3Et7cyDrThfMW ;
     dcat:landingPage <https://www.ag.ch/de/verwaltung/dgs/verbraucherschutz/veterinaerdienst> .
 
-systemmap:101f4674d4654b12bc25fa4a3143f32a a systemmap:FederalOrganization ;
+systemmap:Q1JvEmah9Tl0698au a systemmap:FederalOrganization ;
+    rdfs:label "Direktionsbereich für Digitalisierung und Datenmanagement"@de,
+        "Directorate for Digitalization and Data Management"@en,
+        "Unité de direction Transition numérique et gestion des données"@fr,
+        "Unità di direzione Digitalizzazione e gestione dei dati"@it ;
+    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    rdfs:comment "Der Direktionsbereich Digitalisierung und Datenmanagement setzt sich dafür ein, dass die digitale Transformation und das Datenmanagement in der Land- und Ernährungswirtschaft ziel- und zukunftsgerichtet gefördert werden."@de,
+        "The Directorate for Digitalization and Data Management is committed to ensuring that digital transformation and data management in the agricultural and food sector are promoted in a goal-oriented and forward-looking manner."@en,
+        "La Direction de la numérisation et de la gestion des données s'engage à ce que la transformation numérique et la gestion des données dans le secteur agricole et alimentaire soient encouragées de manière ciblée et tournée vers l'avenir."@fr,
+        "La Direzione per la digitalizzazione e la gestione dei dati si impegna a garantire che la trasformazione digitale e la gestione dei dati nel settore agricolo e alimentare siano promosse in modo mirato e orientato al futuro."@it ;
+    owl:sameAs staatskalender:20034677 ;
+    systemmap:abbreviation "DBDD"@de,
+        "DBDD"@en,
+        "DBDD"@fr,
+        "DBDD"@it .
+
+systemmap:Q2QF8BOhJczC0PGhe a systemmap:FederalOrganization ;
     rdfs:label "Staatssekretariat für Wirtschaft"@de,
         "State Secretariat for Economic Affairs"@en,
         "Secrétariat d'État à l'économie"@fr,
@@ -1406,38 +1422,50 @@ systemmap:101f4674d4654b12bc25fa4a3143f32a a systemmap:FederalOrganization ;
         "SECO"@fr,
         "SECO"@it .
 
-systemmap:4e8ca1ec6eeb4786808a5f71486c4bbf a systemmap:FederalOrganization ;
-    rdfs:label "Bundesamt für Umwelt"@de,
-        "Federal Office for the Environment"@en,
-        "Office fédéral de l'environnement"@fr,
-        "Ufficio federale dell'ambiente"@it ;
-    rdfs:comment """
-        Das Bundesamt für Umwelt (BAFU) ist die Umweltfachstelle der Schweiz und gehört zum Eidgenössischen Departement für Umwelt, Verkehr, Energie und Kommunikation (UVEK).
-        Es ist verantwortlich für die nachhaltige Nutzung der natürlichen Ressourcen sowie den Schutz des Menschen vor Naturgefahren und übermässigen Umweltbelastungen.
-        Gegründet 1971, hat das BAFU seinen Hauptsitz in Bern.
-        """@de,
-        """
-        The Federal Office for the Environment (FOEN) is Switzerland's environmental agency and is part of the Federal Department of the Environment, Transport, Energy and Communications (DETEC).
-        It is responsible for the sustainable use of natural resources and the protection of the population from natural hazards and excessive environmental burdens.
-        Founded in 1971, the FOEN is headquartered in Bern.
-        """@en,
-        """
-        L'Office fédéral de l'environnement (OFEV) est l'autorité environnementale de la Suisse et fait partie du Département fédéral de l'environnement, des transports, de l'énergie et de la communication (DETEC).
-        Il est responsable de l'utilisation durable des ressources naturelles ainsi que de la protection de la population contre les dangers naturels et les charges environnementales excessives.
-        Fondé en 1971, l'OFEV a son siège principal à Berne.
-        """@fr,
-        """
-        L'Ufficio federale dell'ambiente (UFAM) è l'agenzia ambientale della Svizzera e fa parte del Dipartimento federale dell'ambiente, dei trasporti, dell'energia e delle comunicazioni (DATEC).
-        È responsabile dell'uso sostenibile delle risorse naturali e della protezione della popolazione dai pericoli naturali e dalle eccessive pressioni ambientali.
-        Fondato nel 1971, l'UFAM ha la sua sede principale a Berna.
-        """@it ;
-    owl:sameAs staatskalender:10008758 ;
-    systemmap:abbreviation "BAFU"@de,
-        "FOEN"@en,
-        "OFEV"@fr,
-        "UFAM"@it .
+systemmap:Q2tIdqNmt3uS5Ny6D a systemmap:FederalOrganization ;
+    rdfs:label "Bundesamt für Landwirtschaft"@de,
+        "Federal Office for Agriculture"@en,
+        "Office fédéral de l'agriculture"@fr,
+        "Ufficio federale dell'agricoltura"@it ;
+    rdfs:comment "Das Bundesamt für Landwirtschaft (BLW) ist das Kompetenzzentrum des Bundes für alle Kernfragen im Zusammenhang mit dem Agrarsektor."@de,
+        "The Federal Office for Agriculture (FOAG) is the Confederation's competence centre for all core issues relating to the agricultural sector."@en,
+        "L'Office fédéral de l'agriculture (OFAG) est le centre de compétence de la Confédération pour toutes les questions essentielles liées au secteur agricole."@fr,
+        "L'Ufficio federale dell'agricoltura (UFAG) è il centro di competenza della Confederazione per tutte le questioni fondamentali relative al settore agricolo."@it ;
+    owl:sameAs <https://ld.admin.ch/office/VI.1.5>,
+        staatskalender:10008654 ;
+    systemmap:abbreviation "BLW"@de,
+        "FOAG"@en,
+        "OFAG"@fr,
+        "UFAG"@it .
 
-systemmap:5044e9f5dc4347288f5506de98be40af a systemmap:FederalOrganization ;
+systemmap:Q3Rf79NI3Pm1rfOlN a systemmap:FederalOrganization ;
+    rdfs:label "Bundesamt für Lebensmittelsicherheit und Veterinärwesen"@de,
+        "Federal Food Safety and Veterinary Office"@en,
+        "Office fédéral de la sécurité alimentaire et des affaires vétérinaires"@fr,
+        "Ufficio federale della sicurezza alimentare e di veterinaria"@it ;
+    rdfs:comment """  
+        Hauptaufgabe des BLV ist es, die Gesundheit und das Wohlbefinden von Mensch und Tier aktiv zu fördern.  
+        Die Hauptpfeiler dafür sind beim Menschen Lebensmittelsicherheit und gesunde Ernährung und beim Tier Tierschutz und Tiergesundheit.  
+        """@de,
+        """  
+        The main task of the FSVO is to actively promote the health and well-being of humans and animals.  
+        The key pillars for this are food safety and healthy nutrition for humans, and animal welfare and health for animals.  
+        """@en,
+        """  
+        La principale mission de l'OSAV est de promouvoir activement la santé et le bien-être des humains et des animaux.  
+        Les piliers essentiels sont la sécurité alimentaire et une alimentation saine pour les humains, ainsi que la protection et la santé des animaux.  
+        """@fr,
+        """  
+        Il compito principale dell'USAV è promuovere attivamente la salute e il benessere di esseri umani e animali.  
+        I pilastri principali sono la sicurezza alimentare e un'alimentazione sana per gli esseri umani, nonché il benessere e la salute degli animali.  
+        """@it ;
+    owl:sameAs staatskalender:10008671 ;
+    systemmap:abbreviation "BLV"@de,
+        "FSVO"@en,
+        "OSAV"@fr,
+        "USAV"@it .
+
+systemmap:Q8WjMkerPw98ZkWA7 a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Gesundheit"@de,
         "Federal Office of Public Health"@en,
         "Office fédéral de la santé publique"@fr,
@@ -1468,134 +1496,12 @@ systemmap:5044e9f5dc4347288f5506de98be40af a systemmap:FederalOrganization ;
         "OFSP"@fr,
         "UFSP"@it .
 
-systemmap:ORG001 a systemmap:FederalOrganization ;
-    rdfs:label "Bundesamt für Landwirtschaft"@de,
-        "Federal Office for Agriculture"@en,
-        "Office fédéral de l'agriculture"@fr,
-        "Ufficio federale dell'agricoltura"@it ;
-    rdfs:comment "Das Bundesamt für Landwirtschaft (BLW) ist das Kompetenzzentrum des Bundes für alle Kernfragen im Zusammenhang mit dem Agrarsektor."@de,
-        "The Federal Office for Agriculture (FOAG) is the Confederation's competence centre for all core issues relating to the agricultural sector."@en,
-        "L'Office fédéral de l'agriculture (OFAG) est le centre de compétence de la Confédération pour toutes les questions essentielles liées au secteur agricole."@fr,
-        "L'Ufficio federale dell'agricoltura (UFAG) è il centro di competenza della Confederazione per tutte le questioni fondamentali relative al settore agricolo."@it ;
-    owl:sameAs <https://ld.admin.ch/office/VI.1.5>,
-        staatskalender:10008654 ;
-    systemmap:abbreviation "BLW"@de,
-        "FOAG"@en,
-        "OFAG"@fr,
-        "UFAG"@it .
-
-systemmap:ORG002 a systemmap:FederalOrganization ;
-    rdfs:label "Direktionsbereich für Digitalisierung und Datenmanagement"@de,
-        "Directorate for Digitalization and Data Management"@en,
-        "Unité de direction Transition numérique et gestion des données"@fr,
-        "Unità di direzione Digitalizzazione e gestione dei dati"@it ;
-    schema:parentOrganization systemmap:ORG003 ;
-    rdfs:comment "Der Direktionsbereich Digitalisierung und Datenmanagement setzt sich dafür ein, dass die digitale Transformation und das Datenmanagement in der Land- und Ernährungswirtschaft ziel- und zukunftsgerichtet gefördert werden."@de,
-        "The Directorate for Digitalization and Data Management is committed to ensuring that digital transformation and data management in the agricultural and food sector are promoted in a goal-oriented and forward-looking manner."@en,
-        "La Direction de la numérisation et de la gestion des données s'engage à ce que la transformation numérique et la gestion des données dans le secteur agricole et alimentaire soient encouragées de manière ciblée et tournée vers l'avenir."@fr,
-        "La Direzione per la digitalizzazione e la gestione dei dati si impegna a garantire che la trasformazione digitale e la gestione dei dati nel settore agricolo e alimentare siano promosse in modo mirato e orientato al futuro."@it ;
-    owl:sameAs staatskalender:20034677 ;
-    systemmap:abbreviation "DBDD"@de,
-        "DBDD"@en,
-        "DBDD"@fr,
-        "DBDD"@it .
-
-systemmap:ORG003 a systemmap:FederalOrganization ;
-    rdfs:label "Direktion BLW"@de,
-        "Directorate FOAG"@en,
-        "Direction OFAG"@fr,
-        "Direzione UFAG"@it ;
-    schema:parentOrganization systemmap:ORG001 ;
-    owl:sameAs staatskalender:10003196 .
-
-systemmap:ORG004 a systemmap:FederalOrganization ;
-    rdfs:label "Direktionsbereich Recht, Ressourcen und Integrale Sicherheit"@de,
-        "Directorate for Law, Resources, and Integral Security"@en,
-        "Unité de direction Droit, ressources internes et sécurité intégrale"@fr,
-        "Unità di direzione Digitalizzazione e gestione dei dati"@it ;
-    schema:parentOrganization systemmap:ORG003 ;
-    rdfs:comment "Der Direktionsbereich Recht, Ressourcen und Integrale Sicherheit sichert die rechtliche Konformität der verschiedenen BLW-Massnahmen und ist insbesondere für die personellen Massnahmen des Amtes verantwortlich."@de,
-        "The Directorate for Law, Resources, and Integral Security ensures the legal compliance of various BLW measures and is particularly responsible for the office’s personnel measures."@en,
-        "La Direction du droit, des ressources et de la sécurité intégrale garantit la conformité juridique des différentes mesures de l'OFAG et est notamment responsable des mesures en matière de personnel du bureau."@fr,
-        "La Direzione per il diritto, le risorse e la sicurezza integrale garantisce la conformità legale delle varie misure dell'UFAG ed è in particolare responsabile delle misure relative al personale dell'ufficio."@it ;
-    systemmap:abbreviation "DBRRIS"@de,
-        "DBRRIS"@en,
-        "DBRRIS"@fr,
-        "DBRRIS"@it .
-
-systemmap:ORG005 a systemmap:FederalOrganization ;
-    rdfs:label "Direktionsbereich Produktionsgrundlagen, natürliche Ressourcen und Forschung"@de,
-        "Directorate for Production Resources, Natural Resources and Research"@en,
-        "Unité de direction Bases de production, ressources naturelles et recherche"@fr,
-        "Unità di direzione Basi di produzione, risorse naturali e ricerca"@it ;
-    schema:parentOrganization systemmap:ORG003 ;
-    rdfs:comment "Widerstandsfähige Produktions- und Ökosysteme stehen im Zentrum des Direktionsbereichs Produktionsgrundlagen, natürliche Ressourcen und Forschung. So ist er unter anderem dafür zuständig, dass Pflanzen nachhaltig geschützt und Tiere optimal ernährt werden können. Desweitern fördert dieser Bereich verschiedene Forschungs- und Beratungsprojekte in der Schweiz, aber auch international."@de,
-        "Resilient production and ecosystem systems are at the center of the Directorate for Production Resources, Natural Resources and Research. Among other things, it is responsible for ensuring that plants are sustainably protected and animals are optimally fed. Furthermore, this directorate promotes various research and advisory projects in Switzerland and internationally."@en,
-        "Les systèmes de production et les écosystèmes résilients sont au cœur de la Direction des bases de production, des ressources naturelles et de la recherche. Elle est notamment chargée de garantir que les plantes soient protégées durablement et que les animaux soient nourris de manière optimale. De plus, cette direction soutient divers projets de recherche et de conseil en Suisse et à l'international."@fr,
-        "I sistemi produttivi e gli ecosistemi resilienti sono al centro della Direzione delle basi produttive, delle risorse naturali e della ricerca. Tra le altre cose, è responsabile della protezione sostenibile delle piante e dell'alimentazione ottimale degli animali. Inoltre, questa direzione promuove vari progetti di ricerca e consulenza in Svizzera e a livello internazionale."@it ;
-    systemmap:abbreviation "DBPRF"@de,
-        "DBPRF"@en,
-        "DBPRF"@fr,
-        "DBPRF"@it .
-
-systemmap:ORG006 a systemmap:FederalOrganization ;
-    rdfs:label "Direktionsbereich Direktzahlungen und Ländliche Entwicklung"@de,
-        "Directorate for Direct Payments and Rural Development"@en,
-        "Unité de direction Paiements directs et développement rural"@fr,
-        "Unità di direzione Pagamenti diretti e sviluppo rurale"@it ;
-    schema:parentOrganization systemmap:ORG003 ;
-    rdfs:comment "Die Landwirte und Landwirtinnen erbringen verschiedene Leistungen für die Allgemeinheit und werden deshalb mit finanziellen Beiträgen unterstützt. Dafür ist der Direktionsbereich Direktzahlungen und Ländliche Entwicklung zuständig. Er setzt sich zudem für die Vitalität des ländlichen Raums ein."@de,
-        "Farmers provide various services for the general public and are therefore supported with financial contributions. The Directorate for Direct Payments and Rural Development is responsible for this. It also works to ensure the vitality of rural areas."@en,
-        "Les agriculteurs fournissent divers services à la collectivité et sont donc soutenus par des contributions financières. La Direction des paiements directs et du développement rural en est responsable. Elle s'engage également pour la vitalité des zones rurales."@fr,
-        "Gli agricoltori forniscono vari servizi alla collettività e sono quindi sostenuti con contributi finanziari. La Direzione dei pagamenti diretti e dello sviluppo rurale è responsabile di questo. Inoltre, si impegna per la vitalità delle aree rurali."@it ;
-    systemmap:abbreviation "DBDLE"@de .
-
-systemmap:ORG007 a systemmap:FederalOrganization ;
-    rdfs:label "Direktionsbereich Märkte und Internationales"@de,
-        "Directorate for Markets and International Affairs"@en,
-        "Unité de direction Marchés et affaires internationales"@fr,
-        "Unità di direzione Mercati e affari internazionali"@it ;
-    schema:parentOrganization systemmap:ORG003 ;
-    rdfs:comment "Der Direktionsbereich Märkte und Internationales setzt sich dafür ein, dass die Landwirtschaft aus dem Verkauf ihrer Produkte eine möglichst hohe Wertschöpfung erzielen kann. Selbsthilfemassnahmen, Innovation und Vermarktung der verschiedenen Branchen werden unterstützt. Zudem engagiert sich dieser Direktionsbereich in internationalen Organisationen wie der UNO-Ernährungsorganisation FAO oder der Welthandelsorganisation WTO."@de,
-        "The Directorate for Markets and International Affairs works to ensure that agriculture achieves the highest possible added value from the sale of its products. It supports self-help measures, innovation, and the marketing of various sectors. Additionally, this directorate is involved in international organizations such as the UN Food and Agriculture Organization (FAO) and the World Trade Organization (WTO)."@en,
-        "La Direction des marchés et des affaires internationales s'efforce de garantir que l'agriculture tire la plus grande valeur ajoutée possible de la vente de ses produits. Elle soutient les mesures d'auto-assistance, l'innovation et la commercialisation des différentes filières. De plus, cette direction est impliquée dans des organisations internationales telles que l'Organisation des Nations unies pour l'alimentation et l'agriculture (FAO) et l'Organisation mondiale du commerce (OMC)."@fr,
-        "La Direzione dei mercati e degli affari internazionali si adopera affinché l'agricoltura ottenga il massimo valore aggiunto possibile dalla vendita dei suoi prodotti. Sostiene misure di auto-aiuto, innovazione e commercializzazione nei vari settori. Inoltre, questa direzione è coinvolta in organizzazioni internazionali come l'Organizzazione delle Nazioni Unite per l'alimentazione e l'agricoltura (FAO) e l'Organizzazione mondiale del commercio (OMC)."@it ;
-    systemmap:abbreviation "DBMI"@de .
-
-systemmap:ORG008 a systemmap:FederalOrganization ;
-    rdfs:label "Agroscope"@de,
-        "Agroscope"@en,
-        "Agroscope"@fr,
-        "Agroscope"@it ;
-    schema:parentOrganization systemmap:ORG001 ;
-    rdfs:comment """
-        Agroscope ist das Schweizer Kompetenzzentrum für landwirtschaftliche Forschung und engagiert sich für eine nachhaltige Landwirtschaft, hochwertige Lebensmittelproduktion und Umweltschutz.
-        Angeschlossen an das Bundesamt für Landwirtschaft, forscht es entlang der gesamten Wertschöpfungskette der Landwirtschafts- und Ernährungsbranche, von Pflanzenbau und Nutztierhaltung bis hin zu Lebensmitteln und Ernährung.
-        Neben der Forschung bietet Agroscope Politikberatung, Wissensaustausch und Technologietransfer, um ein wettbewerbsfähiges und multifunktionales Agrar- und Ernährungssystem in der Schweiz zu unterstützen.
-        """@de,
-        """
-        Agroscope is the Swiss centre of excellence for agricultural research, dedicated to advancing sustainable agriculture, high-quality food production, and environmental protection .
-        Affiliated with the Federal Office for Agriculture, it conducts research along the entire value chain of the agriculture and food sector, covering topics from plant production and livestock to food and nutrition .
-        In addition to research, Agroscope provides policy advice, knowledge exchange, and technology transfer to support a competitive and multifunctional agri-food system in Switzerland .
-        """@en,
-        """
-        Agroscope est le centre de compétence suisse pour la recherche agricole, dédié à l’agriculture durable, à la production alimentaire de qualité et à la protection de l’environnement.
-        Rattaché à l’Office fédéral de l’agriculture, il mène des recherches tout au long de la chaîne de valeur du secteur agricole et alimentaire, couvrant des sujets allant de la production végétale et de l’élevage à l’alimentation et la nutrition.
-        En plus de la recherche, Agroscope fournit des conseils politiques, des échanges de connaissances et un transfert de technologies pour soutenir un système agroalimentaire compétitif et multifonctionnel en Suisse.
-        """@fr,
-        """
-        Agroscope è il centro di competenza svizzero per la ricerca agricola, impegnato nell'agricoltura sostenibile, nella produzione alimentare di alta qualità e nella protezione ambientale.
-        Affiliato all'Ufficio federale dell'agricoltura, conduce ricerche lungo l'intera catena del valore del settore agricolo e alimentare, coprendo argomenti che vanno dalla produzione vegetale e dall'allevamento fino agli alimenti e alla nutrizione.
-        Oltre alla ricerca, Agroscope fornisce consulenza politica, scambio di conoscenze e trasferimento tecnologico per sostenere un sistema agroalimentare competitivo e multifunzionale in Svizzera.
-        """@it ;
-    owl:sameAs staatskalender:10003634 .
-
-systemmap:ORG010 a systemmap:FederalOrganization ;
+systemmap:QE8y4MuFWW5BKqK92 a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Agrarinformationssysteme"@de,
         "Agricultural Information Systems Division"@en,
         "Secteur d'information sur l'agriculture"@fr,
         "Settore Sistemi d’informazione sull’agricoltura"@it ;
-    schema:parentOrganization systemmap:ORG002 ;
+    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
     rdfs:comment "Der Fachbereich Agrarinformationssysteme ist die zentrale Drehscheibe für Agrardaten. Er ist zuständig für das Portal Agate – den Online-Schalter für die Landwirtschaft – sowie für die zentralen Informationssysteme. Er setzt die fachlichen Vorgaben in technische Lösungen um und gewährleistet eine hohe Datenqualität. Dabei setzen wir auf medienbruchfreie, digitale Prozesse und Standards. FBAIS bietet Schnittstellen an für den Bezug und die Weitergabe der Daten an andere Bundesämter und auch an Dritte ausserhalb der Verwaltung."@de,
         "The Agricultural Information Systems Division is the central hub for agricultural data. It is responsible for the Agate portal – the online gateway for agriculture – as well as for central information systems. It implements professional requirements into technical solutions and ensures high data quality. We rely on seamless, digital processes and standards. FBAIS provides interfaces for retrieving and sharing data with other federal offices and third parties outside the administration."@en,
         "L'Unité des systèmes d'information agricole est la plaque tournante centrale des données agricoles. Elle est responsable du portail Agate – la plateforme en ligne pour l'agriculture – ainsi que des systèmes d'information centraux. Elle met en œuvre les exigences professionnelles en solutions techniques et garantit une haute qualité des données. Nous misons sur des processus et des standards numériques sans rupture. FBAIS propose des interfaces pour l'accès et la transmission des données à d'autres offices fédéraux ainsi qu'à des tiers en dehors de l'administration."@fr,
@@ -1605,12 +1511,12 @@ systemmap:ORG010 a systemmap:FederalOrganization ;
         "FBAIS"@fr,
         "FBAIS"@it .
 
-systemmap:ORG011 a systemmap:FederalOrganization ;
+systemmap:QFAwQAwxBcNnaURgO a systemmap:FederalOrganization ;
     rdfs:label "Kompetenzzentrum für die digitale Transformation"@de,
         "Competence Center for Digital Transformation"@en,
         "Centre de compétence pour la transformation numérique"@fr,
         "Centro di competenza per la trasformazione digitale"@it ;
-    schema:parentOrganization systemmap:ORG002 ;
+    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
     rdfs:comment "Das Kompetenzzentrum für die digitale Transformation widmet sich der Standardisierung und Harmonisierung von Daten im Agrar- und Ernährungssektor und ermöglicht deren Mehrfachnutzung nach dem Once-Only-Prinzip. Es führt und koordiniert die digitale Transformation des Sektors, indem es rechtliche, semantische, technische und organisatorische Herausforderungen angeht. Darüber hinaus fördert es die Kommunikation zwischen den Akteuren, um einen reibungslosen und effektiven Übergang zu digitalen Prozessen zu gewährleisten."@de,
         "The Competence Center for Digital Transformation is dedicated to standardizing and harmonizing data in the agri-food sector while enabling multiple data uses through the Once-Only Principle. It leads and coordinates the sector’s digital transformation by addressing legal, semantic, technical, and organizational challenges. Additionally, it fosters communication among stakeholders to ensure a smooth and effective transition to digital processes."@en,
         "Le Centre de compétence pour la transformation numérique se consacre à la standardisation et à l'harmonisation des données dans le secteur agroalimentaire, tout en permettant leur réutilisation multiple selon le principe du « Once-Only ». Il dirige et coordonne la transformation numérique du secteur en relevant les défis juridiques, sémantiques, techniques et organisationnels. De plus, il favorise la communication entre les parties prenantes afin d'assurer une transition fluide et efficace vers des processus numériques."@fr,
@@ -1620,417 +1526,7 @@ systemmap:ORG011 a systemmap:FederalOrganization ;
         "GRKDT"@fr,
         "GRKDT"@it .
 
-systemmap:ORG012 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Marktanalyse"@de,
-        "Market Analysis Division"@en,
-        "Secteur analyses du marché"@fr,
-        "Settore analisi di mercato"@it ;
-    schema:parentOrganization systemmap:ORG002 ;
-    rdfs:comment """
-        Der Fachbereich Marktanalysen informiert regelmässig über die Preisentwicklung in den Agrarmärkten mit dem Ziel, die Markttransparenz zu erhöhen und langfristige Entwicklungen aufzuzeigen.
-        Dazu werden in verschiedenen Marktbereichen Preise entlang der Wertschöpfungsketten erhoben und ausgewiesen sowie datengestützte Marktanalysen erstellt.
-        """@de,
-        """
-        The Market Analysis Division regularly provides information on price developments in agricultural markets with the aim of increasing market transparency and highlighting long-term trends.
-        To this end, prices are collected and reported along the value chains in various market sectors, and data-driven market analyses are created.
-        """@en,
-        """
-        Le Secteur analyses du marché informe régulièrement sur l'évolution des prix sur les marchés agricoles dans le but d'accroître la transparence du marché et de mettre en évidence les tendances à long terme.
-        À cette fin, les prix sont collectés et publiés tout au long des chaînes de valeur dans divers secteurs du marché, et des analyses de marché basées sur les données sont élaborées.
-        """@fr,
-        """
-        Il Settore analisi di mercato informa regolarmente sull'andamento dei prezzi nei mercati agricoli con l'obiettivo di aumentare la trasparenza del mercato e evidenziare le tendenze a lungo termine.
-        A tal fine, i prezzi vengono raccolti e riportati lungo le catene del valore in vari settori di mercato e vengono create analisi di mercato basate sui dati.
-        """@it ;
-    systemmap:abbreviation "FBMA"@de,
-        "MAD"@en,
-        "SAM"@fr,
-        "SAM"@it ;
-    systemmap:hasLegalBasis LwG:art_27,
-        <https://www.fedlex.admin.ch/eli/cc/1999/71> .
-
-systemmap:ORG013 a systemmap:FederalOrganization ;
-    rdfs:label "Business Intelligence Competence Center"@de,
-        "Business Intelligence Competence Center"@en,
-        "Centre de compétence Business Intelligence"@fr,
-        "Centro di competenza Business Intelligence"@it ;
-    schema:parentOrganization systemmap:ORG002 ;
-    rdfs:comment """  
-        Das Business Intelligence Competence Center (BI) ist verantwortlich für die Entwicklung und Umsetzung der BI-Strategie sowie die Planung und Durchführung von BI-Projekten.  
-        Zu seinen Aufgaben gehören die Datenvisualisierung, das Reporting, die Beratung und Schulung von BI-Fachanwendern sowie die Analyse, Modellierung und Integration von Daten.  
-        Zudem koordiniert das BI-Team den Betrieb von ASTAT mit dem ISCeco und die BI-Aktivitäten mit dem BLV.  
-        """@de,
-        """  
-        The Business Intelligence Competence Center (BI) is responsible for developing and implementing the BI strategy, as well as planning and executing BI projects.  
-        Its tasks include data visualization, reporting, advising and training BI professionals, as well as data analysis, modeling, and integration.  
-        Additionally, the BI team coordinates the operation of ASTAT with ISCeco and BI activities with the FSVO.  
-        """@en,
-        """  
-        Le Centre de compétence Business Intelligence (BI) est responsable du développement et de la mise en œuvre de la stratégie BI, ainsi que de la planification et de l'exécution des projets BI.  
-        Ses tâches incluent la visualisation des données, le reporting, le conseil et la formation des spécialistes BI, ainsi que l'analyse, la modélisation et l'intégration des données.  
-        De plus, l'équipe BI coordonne l'exploitation d'ASTAT avec l'ISCeco et les activités BI avec l'OSAV.  
-        """@fr,
-        """  
-        Il Centro di competenza Business Intelligence (BI) è responsabile dello sviluppo e dell'implementazione della strategia BI, nonché della pianificazione e dell'esecuzione dei progetti BI.  
-        I suoi compiti includono la visualizzazione dei dati, il reporting, la consulenza e la formazione degli specialisti BI, oltre all'analisi, alla modellazione e all'integrazione dei dati.  
-        Inoltre, il team BI coordina il funzionamento di ASTAT con ISCeco e le attività BI con l'USAV.  
-        """@it ;
-    systemmap:abbreviation "GRBI"@de,
-        "GRBI"@en,
-        "GRBI"@fr,
-        "GRBI"@it .
-
-systemmap:ORG020 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Direktzahlungsprogramme"@de,
-        "Direct Payment Programs Division"@en,
-        "Secteur Paiements directs - Programmes"@fr,
-        "Settore Pagamenti diretti - Programmi"@it ;
-    schema:parentOrganization systemmap:ORG006 ;
-    rdfs:comment """
-        Der Fachbereich setzt Direktzahlungsprogramme in den Bereichen Umwelt, Tierwohl und Landschaft um, unterstützt kantonale Stellen und überwacht deren Vollzug.  
-        Zudem wird der ökologische Leistungsnachweis (ÖLN) weiterentwickelt, Regelbereiche wie Biodiversitätsstrategie, Biolandbau sowie Energie- und Klimaschutz koordiniert und relevante Gesetzgebungsschnittstellen gepflegt.  
-        Technisch werden EDV-Applikationen bereitgestellt und Kürzungsmassnahmen umgesetzt. Weitere Aufgaben umfassen die Bearbeitung von Stellungnahmen, Öffentlichkeitsarbeit sowie die Information und Einbindung relevanter Akteure.  
-        """@de,
-        """
-        The division implements direct payment programs in the areas of environment, animal welfare, and landscape, supports cantonal authorities, and monitors their enforcement.  
-        Additionally, it develops the ecological performance record (ÖLN), coordinates regulatory areas such as biodiversity strategy, organic farming, and energy and climate protection, and maintains relevant legislative interfaces.  
-        On a technical level, IT applications are provided, and reduction measures are implemented. Other tasks include handling statements, public relations, and informing and involving relevant stakeholders.  
-        """@en,
-        """
-        Le secteur met en œuvre des programmes de paiements directs dans les domaines de l'environnement, du bien-être animal et du paysage, soutient les autorités cantonales et supervise leur application.  
-        De plus, il développe la preuve écologique de performance (ÖLN), coordonne des domaines réglementaires tels que la stratégie de biodiversité, l'agriculture biologique ainsi que la protection de l’énergie et du climat, et entretient les interfaces législatives pertinentes.  
-        Sur le plan technique, des applications informatiques sont mises à disposition et des mesures de réduction sont appliquées. D'autres tâches comprennent le traitement des avis, les relations publiques ainsi que l'information et l'implication des acteurs concernés.  
-        """@fr,
-        """
-        Il settore attua programmi di pagamenti diretti nei settori dell’ambiente, del benessere animale e del paesaggio, supporta le autorità cantonali e ne monitora l’attuazione.  
-        Inoltre, sviluppa la prova delle prestazioni ecologiche (ÖLN), coordina ambiti normativi come la strategia per la biodiversità, l’agricoltura biologica, la protezione dell’energia e del clima e gestisce le interfacce legislative pertinenti.  
-        A livello tecnico, vengono fornite applicazioni informatiche e implementate misure di riduzione. Altri compiti includono la gestione delle dichiarazioni, le relazioni pubbliche e il coinvolgimento degli attori interessati.  
-        """@it ;
-    owl:sameAs staatskalender:10003227 ;
-    systemmap:abbreviation "FBDP"@de,
-        "FBDP"@en,
-        "FBDP"@fr,
-        "FBDP"@it .
-
-systemmap:ORG021 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Direktzahlungsgrundlagen"@de,
-        "Direct Payment Principles Division"@en,
-        "Secteur bases des paiements directs"@fr,
-        "Settore basi dei pagamenti diretti"@it ;
-    schema:parentOrganization systemmap:ORG006 ;
-    rdfs:comment """  
-        Der Fachbereich Direktzahlungsgrundlagen ist zuständig für die Umsetzung und Weiterentwicklung des Direktzahlungssystems im Bereich der Versorgungssicherheit,  
-        der Kulturlandschaft, der Übergangsbeiträge, der landwirtschaftlichen Zonen und Gebiete, der landwirtschaftlichen Begriffe sowie der Anerkennung von Betrieben und Betriebsformen.  
-        """@de,
-        """  
-        The Direct Payment Principles Division is responsible for implementing and further developing the direct payment system  
-        in the areas of food security, cultural landscape, transitional payments, agricultural zones and areas, agricultural terminology,  
-        and the recognition of farms and farming models.  
-        """@en,
-        """  
-        Le secteur bases des paiements directs est responsable de la mise en œuvre et du développement du système des paiements directs  
-        dans les domaines de la sécurité de l'approvisionnement, du paysage culturel, des contributions transitoires,  
-        des zones et régions agricoles, de la terminologie agricole ainsi que de la reconnaissance des exploitations et des modèles d’exploitation.  
-        """@fr,
-        """  
-        Il settore basi dei pagamenti diretti è responsabile dell'attuazione e dello sviluppo del sistema dei pagamenti diretti  
-        nei settori della sicurezza dell'approvvigionamento, del paesaggio culturale, dei contributi transitori,  
-        delle zone e aree agricole, della terminologia agricola e del riconoscimento delle aziende e dei modelli aziendali.  
-        """@it ;
-    owl:sameAs staatskalender:10003228 ;
-    systemmap:abbreviation "FBDG"@de,
-        "FBDG"@en,
-        "FBDG"@fr,
-        "FBDG"@it .
-
-systemmap:ORG022 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Meliorationen"@de ;
-    schema:parentOrganization systemmap:ORG006 ;
-    rdfs:comment """
-        Der Fachbereich Meliorationen ist in der Verbundaufgabe mit den Kantonen im ländlichen Tiefbau (Bodenverbesserungen) tätig.
-        Er ist bundesintern verfahrensleitende Behörde, beurteilt die Gesuche und übt die Oberaufsicht aus.
-        Zudem behandelt er Fragen der Raumplanung und der Infrastrukturen.
-        Weitere Themen sind Management natürlicher Ressourcen, Klimawandel mit Blick auf Boden/Wasserhaushalt.
-        """@de .
-
-systemmap:ORG030 a systemmap:FederalOrganization ;
-    rdfs:label "Genetische Ressourcen, Produktionssicherheit und Futtermittel"@de,
-        "Genetic Resources, Production Safety and Animal Feed"@en,
-        "Ressources génétiques, sécurité de la production et aliments pour animaux"@fr,
-        "Risorse genetiche, sicurezza della produzione e mangimi"@it ;
-    schema:parentOrganization systemmap:ORG005 ;
-    rdfs:comment """  
-        Der Fachbereich Genetische Ressourcen, Produktionssicherheit und Futtermittel ist verantwortlich für den Erhalt und die nachhaltige Nutzung pflanzengenetischer Ressourcen,  
-        die Überwachung der Gentechnologie in der Landwirtschaft sowie die Identifikation und Regulierung von Risiken in der landwirtschaftlichen Produktion.  
-        Zudem übernimmt er das Ereignis- und Krisenmanagement bei ABCN-Ereignissen und koordiniert die Futtermittelkontrolle sowie die Weiterentwicklung der entsprechenden Verordnungen.  
-        Ein weiterer Schwerpunkt liegt auf der Tiergesundheit, insbesondere durch die Förderung von Innovationen, Antibiotikaresistenzstrategien und den One-Health-Ansatz.  
-        """@de,
-        """  
-        The Genetic Resources, Production Safety and Animal Feed Division is responsible for the conservation and sustainable use of plant genetic resources,  
-        the monitoring of agricultural biotechnology, and the identification and regulation of risks in agricultural production.  
-        It also manages incident and crisis response for ABCN events and coordinates animal feed control and the development of relevant regulations.  
-        Another focus is on animal health, particularly through the promotion of innovations, antibiotic resistance strategies, and the One Health approach.  
-        """@en,
-        """  
-        Le secteur Ressources génétiques, sécurité de la production et aliments pour animaux est responsable de la conservation et de l'utilisation durable des ressources génétiques végétales,  
-        de la surveillance de la biotechnologie agricole et de l'identification et de la régulation des risques dans la production agricole.  
-        Il gère également la réponse aux incidents et aux crises en cas d’événements ABCN et coordonne le contrôle des aliments pour animaux ainsi que l'évolution des réglementations correspondantes.  
-        Un autre axe majeur concerne la santé animale, notamment à travers la promotion des innovations, des stratégies de lutte contre la résistance aux antibiotiques et l'approche One Health.  
-        """@fr,
-        """  
-        Il settore Risorse genetiche, sicurezza della produzione e mangimi è responsabile della conservazione e dell’uso sostenibile delle risorse genetiche vegetali,  
-        del monitoraggio delle biotecnologie agricole e dell’identificazione e regolamentazione dei rischi nella produzione agricola.  
-        Inoltre, gestisce la risposta a incidenti e crisi legati a eventi ABCN e coordina il controllo dei mangimi e lo sviluppo delle normative pertinenti.  
-        Un altro punto focale è la salute animale, in particolare attraverso la promozione di innovazioni, strategie contro la resistenza agli antibiotici e l’approccio One Health.  
-        """@it ;
-    owl:sameAs staatskalender:20011808 ;
-    systemmap:abbreviation "FBGRT"@de,
-        "FBGRT"@en,
-        "FBGRT"@fr,
-        "FBGRT"@it .
-
-systemmap:ORG031 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Pflanzengesundheit"@de,
-        "Plant Health Division"@en,
-        "Secteur santé des végétaux"@fr,
-        "Settore salute delle piante"@it ;
-    schema:parentOrganization systemmap:ORG005 ;
-    rdfs:comment """  
-        Die Aufgabe des Fachbereiches Pflanzengesundheit (FBPG) ist es, die Einschleppung und Ausbreitung von (geregelten) besonders gefährlichen Schädlingen und Krankheiten von Pflanzen zu vermeiden.  
-        Dies ist wichtig, um wirtschaftliche, soziale und ökologische Schäden zu vermeiden.  
-        Der Eidgenössische Pflanzenschutzdienst (EPSD), der vom Fachbereich gemeinsam mit der Sektion Waldschutz und Waldgesundheit des Bundesamts für Umwelt (BAFU) geführt wird, ist für die Umsetzung dieser Aufgabe auf nationaler Ebene zuständig.  
-        """@de,
-        """  
-        The task of the Plant Health Division (FBPG) is to prevent the introduction and spread of (regulated) particularly dangerous plant pests and diseases.  
-        This is important to avoid economic, social, and environmental damage.  
-        The Swiss Plant Protection Service (EPSD), managed jointly by the division and the Forest Protection and Health Section of the Federal Office for the Environment (FOEN), is responsible for implementing this task at the national level.  
-        """@en,
-        """  
-        La mission du secteur santé des végétaux (FBPG) est d'éviter l'introduction et la propagation de ravageurs et de maladies des plantes particulièrement dangereux (réglementés).  
-        Cela est essentiel pour prévenir des dommages économiques, sociaux et environnementaux.  
-        Le Service fédéral de la protection des végétaux (EPSD), géré conjointement par le secteur et la section Protection et santé des forêts de l'Office fédéral de l'environnement (OFEV), est responsable de la mise en œuvre de cette mission au niveau national.  
-        """@fr,
-        """  
-        Il compito del settore salute delle piante (FBPG) è prevenire l'introduzione e la diffusione di parassiti e malattie delle piante particolarmente pericolosi (regolamentati).  
-        Questo è fondamentale per evitare danni economici, sociali e ambientali.  
-        Il Servizio fitosanitario federale (EPSD), gestito congiuntamente dal settore e dalla Sezione protezione e salute delle foreste dell'Ufficio federale dell'ambiente (UFAM), è responsabile dell'attuazione di questo compito a livello nazionale.  
-        """@it ;
-    systemmap:abbreviation "FBPG"@de,
-        "FBPG"@en,
-        "FBPG"@fr,
-        "FBPG"@it .
-
-systemmap:ORG032 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich nachhaltiger Pflanzenschutz und Sorten"@de,
-        "Sustainable Plant Protection and Varieties Division"@en,
-        "Secteur protection durable des végétaux et variétés"@fr,
-        "Settore protezione sostenibile delle piante e varietà"@it ;
-    schema:parentOrganization systemmap:ORG005 ;
-    rdfs:comment """  
-        Der Fachbereich nachhaltiger Pflanzenschutz und Sorten (FB NPS) sorgt für den Schutz der Kulturen, den Vollzug des Saatgutrechtes und den Sortenschutz.  
-        Dabei werden sowohl präventive als auch direkte Pflanzenschutzmassnahmen angewendet, um hochwertige Lebensmittel zu produzieren.  
-        Zudem ist das BLW für die Weiterentwicklung der Verordnungen zu Vermehrungsmaterial, den Nationalen Sortenkatalog und den Vollzug der Bestimmungen in Zusammenarbeit mit Agroscope verantwortlich.  
-        """@de,
-        """  
-        The Sustainable Plant Protection and Varieties Division (FBNPS) ensures crop protection, enforces seed law, and manages variety protection.  
-        Both preventive and direct plant protection measures are applied to produce high-quality food.  
-        Additionally, the FOAG is responsible for developing regulations on propagation material, maintaining the National Variety Catalogue, and enforcing regulations in collaboration with Agroscope.  
-        """@en,
-        """  
-        Le secteur protection durable des végétaux et variétés (FBNPS) assure la protection des cultures, l'application du droit des semences et la protection des variétés.  
-        Des mesures de protection des plantes, tant préventives que directes, sont mises en œuvre pour produire des denrées alimentaires de haute qualité.  
-        De plus, l'OFAG est responsable du développement des réglementations sur le matériel de multiplication, du catalogue national des variétés et de l'application des dispositions en collaboration avec Agroscope.  
-        """@fr,
-        """  
-        Il settore protezione sostenibile delle piante e varietà (FBNPS) garantisce la protezione delle colture, l'applicazione della legislazione sulle sementi e la tutela delle varietà.  
-        Vengono applicate misure di protezione delle piante sia preventive che dirette per produrre alimenti di alta qualità.  
-        Inoltre, l'UFAG è responsabile dello sviluppo delle normative sul materiale di propagazione, del catalogo nazionale delle varietà e dell'applicazione delle disposizioni in collaborazione con Agroscope.  
-        """@it ;
-    systemmap:abbreviation "FBNPS"@de,
-        "FBNPS"@en,
-        "FBNPS"@fr,
-        "FBNPS"@it .
-
-systemmap:ORG040 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Ein- und Ausfuhr"@de,
-        "Specialized Unit for Import and Export"@en,
-        "Secteur Importations et exportations"@fr,
-        "Settore Importazioni ed esportazioni"@it ;
-    schema:parentOrganization systemmap:ORG007 ;
-    rdfs:comment """
-        Zu den Hauptaufgaben des Fachbereichs Ein- und Ausfuhr (FBEA) gehören die Verwaltung der Zollkontingente, die Erteilung von Einfuhrbewilligungen, die Zuteilung von Kontingentsanteilen, die Koordination mit der Oberzolldirektion sowie die Durchführung von internen und externen Kontrollen.
-        Zudem kümmert sich der FBEA um die Gebührenverwaltung, den Betrieb und die Wartung von Fachapplikationen, die Bearbeitung von Gesuchen im Veredelungsverkehr und um Exportberatungen.
-        """@de,
-        """
-        The main tasks of the Specialized Unit for Import and Export (FBEA) include the management of tariff quotas, the issuance of import permits, the allocation of quota shares, coordination with the Federal Customs Directorate, and the execution of internal and external controls.
-        Additionally, the FBEA handles fee management, the operation and maintenance of specialized applications, the processing of applications for inward processing, and export consulting.
-        """@en,
-        """
-        Les principales tâches de l'Unité spécialisée Importation et Exportation (FBEA) comprennent la gestion des contingents tarifaires, la délivrance des autorisations d'importation, l'attribution des parts de contingent, la coordination avec la Direction générale des douanes et l'exécution des contrôles internes et externes.
-        De plus, le FBEA s'occupe de la gestion des taxes, de l'exploitation et de la maintenance des applications spécialisées, du traitement des demandes dans le cadre du perfectionnement actif et du conseil en exportation.
-        """@fr,
-        """
-        I principali compiti dell'Unità specializzata Importazione ed Esportazione (FBEA) comprendono la gestione delle contingenti tariffari, il rilascio delle autorizzazioni all'importazione, l'assegnazione delle quote di contingente, il coordinamento con la Direzione Generale delle Dogane e l'esecuzione di controlli interni ed esterni.
-        Inoltre, il FBEA si occupa della gestione delle tasse, del funzionamento e della manutenzione delle applicazioni specializzate, dell'elaborazione delle domande nel traffico di perfezionamento attivo e della consulenza all'esportazione.
-        """@it ;
-    owl:sameAs staatskalender:10003223 ;
-    systemmap:abbreviation "FBEA"@de,
-        "SIE"@fr .
-
-systemmap:ORG041 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Tierische Produkte und Tierzucht"@de,
-        "Sector Animal Products and Breeding"@en,
-        "Secteur Produits animaux et élevage"@fr,
-        "Settore Prodotti animali e allevamento"@it ;
-    schema:parentOrganization systemmap:ORG007 ;
-    rdfs:comment "Die Mitgestaltung der agrarpolitischen Rahmenbedingungen und deren Weiterentwicklung im Bereich der tierischen Produkte und der Tierzucht gehören zu den Kernaufgaben des FBTT. Weiter stellt er den reibungslosen und korrekten Vollzug der einschlägigen Bestimmungen des Landwirtschaftsgesetzes und folgender Bundesratsverordnungen sicher: Milchpreisstützungsverordnung, Schlachtviehverordnung, Eierverordnung, Verordnung über die Identitas AG und die Tierverkehrsdatenbank, Entsorgungsbeitragsverordnung, Landwirtschaftliche Deklarationsverordnung, Höchstbestandesverordnung, Verordnung über die Branchen- und Produzentenorganisationen, Schafwollverordnung und Tierzuchtverordnung."@de,
-        "The design and further development of agricultural policy framework conditions in the field of animal products and breeding are among the core tasks of the SPAE. Furthermore, it ensures the smooth and correct implementation of the relevant provisions of the Agricultural Act and the following Federal Council ordinances: Milk Price Support Ordinance, Slaughter Livestock Ordinance, Egg Ordinance, Ordinance on Identitas AG and the Animal Traffic Database, Disposal Contribution Ordinance, Agricultural Declaration Ordinance, Maximum Stock Ordinance, Ordinance on Sector and Producer Organizations, Sheep Wool Ordinance, and Breeding Ordinance."@en,
-        "La conception et le développement des cadres politiques agricoles dans le domaine des produits animaux et de l'élevage font partie des missions principales du SPAE. Il veille également à la mise en œuvre correcte et sans heurts des dispositions pertinentes de la loi agricole et des ordonnances suivantes du Conseil fédéral : Ordonnance sur le soutien des prix du lait, Ordonnance sur le bétail de boucherie, Ordonnance sur les œufs, Ordonnance sur Identitas AG et la base de données sur le trafic des animaux, Ordonnance sur la contribution à l'élimination, Ordonnance sur la déclaration agricole, Ordonnance sur le nombre maximal d'animaux, Ordonnance sur les organisations de filières et de producteurs, Ordonnance sur la laine de mouton et Ordonnance sur l'élevage."@fr,
-        "La progettazione e lo sviluppo del quadro politico agricolo nel settore dei prodotti animali e dell'allevamento sono tra i compiti principali dello SPAA. Inoltre, garantisce l'attuazione fluida e corretta delle disposizioni pertinenti della legge sull'agricoltura e delle seguenti ordinanze del Consiglio federale: Ordinanza sul sostegno del prezzo del latte, Ordinanza sul bestiame da macello, Ordinanza sulle uova, Ordinanza su Identitas AG e la banca dati sul traffico degli animali, Ordinanza sul contributo per lo smaltimento, Ordinanza sulla dichiarazione agricola, Ordinanza sul numero massimo di capi, Ordinanza sulle organizzazioni di settore e di produttori, Ordinanza sulla lana di pecora e Ordinanza sulla selezione degli animali."@it ;
-    owl:sameAs staatskalender:10003217 ;
-    systemmap:abbreviation "FBTT"@de,
-        "FBTT"@en,
-        "SPAE"@fr,
-        "SPAA"@it ;
-    systemmap:access systemmap:INF020,
-        systemmap:INF021,
-        systemmap:INF022,
-        systemmap:INF023 .
-
-systemmap:ORG201 a systemmap:FederalOrganization ;
-    rdfs:label "Abteilung Wissensgrundlagen"@de,
-        "Knowledge Foundations Division"@en,
-        "Département des bases de connaissances"@fr,
-        "Dipartimento delle basi di conoscenza"@it ;
-    schema:parentOrganization systemmap:ORG211 ;
-    rdfs:comment """
-        Die Abteilung Wissensgrundlagen unterstützt das Bundesamt für Lebensmittelsicherheit und Veterinärwesen (BLV) durch Förderung der Verfügbarkeit und Nutzung von Daten, Kompetenzen, Verfahren und Wissen.
-        Sie beurteilt gesundheitliche Risiken für Mensch und Tier und stellt sicher, dass der aktuelle Wissensstand erfasst und bei Bedarf durch externe Expertise ergänzt wird.
-        Dadurch werden Risiken frühzeitig erkannt und wissenschaftlich eingeordnet.
-        """@de,
-        """
-        The Knowledge Foundations Division supports the Federal Food Safety and Veterinary Office (FSVO) by promoting the availability and use of data, skills, processes, and knowledge.
-        It assesses health risks to humans and animals and ensures that current knowledge is recorded and supplemented by external expertise when necessary.
-        This enables early identification and scientific classification of risks.
-        """@en,
-        """
-        Le Département des bases de connaissances soutient l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) en favorisant la disponibilité et l'utilisation des données, compétences, processus et connaissances.
-        Il évalue les risques sanitaires pour l'homme et l'animal et veille à ce que les connaissances actuelles soient recensées et, si nécessaire, complétées par des expertises externes.
-        Ainsi, les risques sont identifiés et classés scientifiquement à un stade précoce.
-        """@fr,
-        """
-        Il Dipartimento delle basi di conoscenza supporta l'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) promuovendo la disponibilità e l'utilizzo di dati, competenze, processi e conoscenze.
-        Valuta i rischi per la salute di uomini e animali e garantisce che le conoscenze attuali siano registrate e, se necessario, integrate da competenze esterne.
-        In questo modo, i rischi possono essere identificati e classificati scientificamente in una fase precoce.
-        """@it ;
-    owl:sameAs staatskalender:20035163 .
-
-systemmap:ORG202 a systemmap:FederalOrganization ;
-    rdfs:label "Abteilung Tiergesundheit und Tierschutz"@de,
-        "Animal Health and Welfare Division"@en,
-        "Département de la santé et de la protection des animaux"@fr,
-        "Dipartimento della salute e della protezione degli animali"@it ;
-    schema:parentOrganization systemmap:ORG211 ;
-    rdfs:comment """
-        Die Abteilung Tiergesundheit und Tierschutz des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) fördert die Gesundheit und das Wohlbefinden von Tieren.
-        Sie arbeitet eng mit Tierhalterorganisationen und Vollzugsorganen zusammen, basierend auf wissenschaftlichen Grundlagen.
-        Die Abteilung ist in sechs Fachbereiche unterteilt: Tierseuchenprävention, Tierseuchenbekämpfung, Tierarzneimittel, Nutztierhaltung, Tierschutz Haus- und Wildtiere sowie Tierversuche.
-        """@de,
-        """
-        The Animal Health and Welfare Division of the Federal Food Safety and Veterinary Office (FSVO) promotes the health and well-being of animals.
-        It collaborates closely with animal owner organizations and enforcement bodies, based on scientific foundations.
-        The division is divided into six specialized areas: epizootic disease prevention, epizootic disease control, veterinary medicines, livestock farming, protection of domestic and wild animals, and animal experimentation.
-        """@en,
-        """
-        Le Département de la santé et de la protection des animaux de l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) promeut la santé et le bien-être des animaux.
-        Il collabore étroitement avec les organisations d'éleveurs et les organes d'exécution, en s'appuyant sur des bases scientifiques.
-        Le département est divisé en six domaines spécialisés : prévention des épizooties, lutte contre les épizooties, médicaments vétérinaires, élevage des animaux de rente, protection des animaux domestiques et sauvages, ainsi que les expériences sur animaux.
-        """@fr,
-        """
-        Il Dipartimento della salute e della protezione degli animali dell'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) promuove la salute e il benessere degli animali.
-        Collabora strettamente con le organizzazioni di allevatori e gli organi di esecuzione, basandosi su fondamenti scientifici.
-        Il dipartimento è suddiviso in sei settori specialistici: prevenzione delle epizoozie, lotta contro le epizoozie, medicinali veterinari, allevamento degli animali da reddito, protezione degli animali domestici e selvatici, nonché sperimentazione animale.
-        """@it ;
-    owl:sameAs staatskalender:20035164 .
-
-systemmap:ORG203 a systemmap:FederalOrganization ;
-    rdfs:label "Abteilung Lebensmittel und Ernährung"@de,
-        "Food and Nutrition Division"@en,
-        "Département denrées alimentaires et nutrition"@fr,
-        "Dipartimento alimenti e nutrizione"@it ;
-    schema:parentOrganization systemmap:ORG211 ;
-    rdfs:comment """
-        Die Abteilung Lebensmittel und Ernährung des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) ist verantwortlich für die Sicherheit und Qualität von Lebensmitteln sowie die Förderung einer gesunden Ernährung.
-        Sie entwickelt Richtlinien und überwacht die Einhaltung von Standards, um die Gesundheit der Bevölkerung zu schützen.
-        Zudem informiert sie die Öffentlichkeit über ernährungsrelevante Themen und arbeitet mit nationalen sowie internationalen Partnern zusammen.
-        """@de,
-        """
-        The Food and Nutrition Division of the Federal Food Safety and Veterinary Office (FSVO) is responsible for the safety and quality of food products, as well as promoting healthy nutrition.
-        It develops guidelines and monitors compliance with standards to protect public health.
-        Additionally, it informs the public about nutritional issues and collaborates with national and international partners.
-        """@en,
-        """
-        Le Département denrées alimentaires et nutrition de l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) est responsable de la sécurité et de la qualité des denrées alimentaires ainsi que de la promotion d'une alimentation saine.
-        Il élabore des directives et surveille le respect des normes afin de protéger la santé de la population.
-        De plus, il informe le public sur les questions nutritionnelles et collabore avec des partenaires nationaux et internationaux.
-        """@fr,
-        """
-        Il Dipartimento alimenti e nutrizione dell'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) è responsabile della sicurezza e della qualità degli alimenti, nonché della promozione di una sana alimentazione.
-        Sviluppa linee guida e monitora il rispetto degli standard per proteggere la salute della popolazione.
-        Inoltre, informa il pubblico su temi nutrizionali e collabora con partner nazionali e internazionali.
-        """@it ;
-    owl:sameAs staatskalender:20035162 .
-
-systemmap:ORG204 a systemmap:FederalOrganization ;
-    rdfs:label "Zulassungsstelle Pflanzenschutzmittel"@de,
-        "Plant Protection Products Registration Authority"@en,
-        "Autorité d'homologation des produits phytosanitaires"@fr,
-        "Autorità di omologazione dei prodotti fitosanitari"@it ;
-    schema:parentOrganization systemmap:ORG211 ;
-    rdfs:comment """
-        Die Zulassungsstelle Pflanzenschutzmittel des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) ist für die Zulassung und Überprüfung von Pflanzenschutzmitteln in der Schweiz verantwortlich.
-        Sie stellt sicher, dass nur sichere und wirksame Pflanzenschutzmittel auf den Markt gelangen, indem sie deren gesundheitliche und ökologische Auswirkungen sorgfältig bewertet.
-        Seit dem 1. Januar 2022 liegt die Zuständigkeit für die Zulassung von Pflanzenschutzmitteln beim BLV, während das Bundesamt für Umwelt (BAFU) die Hauptverantwortung für die Beurteilung der Umweltrisiken übernimmt.
-        """@de,
-        """
-        The Plant Protection Products Registration Authority of the Federal Food Safety and Veterinary Office (FSVO) is responsible for the authorization and review of plant protection products in Switzerland.
-        It ensures that only safe and effective products are placed on the market by carefully evaluating their health and ecological impacts.
-        Since January 1, 2022, the responsibility for the authorization of plant protection products lies with the FSVO, while the Federal Office for the Environment (FOEN) assumes primary responsibility for assessing environmental risks.
-        """@en,
-        """
-        L'Autorité d'homologation des produits phytosanitaires de l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) est responsable de l'autorisation et de la révision des produits phytosanitaires en Suisse.
-        Elle veille à ce que seuls des produits sûrs et efficaces soient mis sur le marché en évaluant soigneusement leurs impacts sanitaires et écologiques.
-        Depuis le 1er janvier 2022, la compétence pour l'autorisation des produits phytosanitaires relève de l'OSAV, tandis que l'Office fédéral de l'environnement (OFEV) assume la responsabilité principale de l'évaluation des risques environnementaux.
-        """@fr,
-        """
-        L'Autorità di omologazione dei prodotti fitosanitari dell'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) è responsabile dell'autorizzazione e della revisione dei prodotti fitosanitari in Svizzera.
-        Garantisce che solo prodotti sicuri ed efficaci siano immessi sul mercato, valutando attentamente i loro impatti sulla salute e sull'ecologia.
-        Dal 1° gennaio 2022, la competenza per l'autorizzazione dei prodotti fitosanitari spetta all'USAV, mentre l'Ufficio federale dell'ambiente (UFAM) ha la responsabilità principale della valutazione dei rischi ambientali.
-        """@it ;
-    owl:sameAs staatskalender:20049676 .
-
-systemmap:ORG205 a systemmap:FederalOrganization ;
-    rdfs:label "Kompetenzzentrum Daten"@de ;
-    schema:parentOrganization systemmap:ORG201 ;
-    owl:sameAs staatskalender:20051877 ;
-    systemmap:abbreviation "DCC"@de .
-
-systemmap:ORG206 a systemmap:FederalOrganization ;
-    rdfs:label "Toxikologie Pflanzenschutzmittel"@de ;
-    schema:parentOrganization systemmap:ORG201 ;
-    owl:sameAs staatskalender:20035173 .
-
-systemmap:ORG207 a systemmap:FederalOrganization ;
-    rdfs:label "Risikobewertung"@de ;
-    schema:parentOrganization systemmap:ORG201 ;
-    owl:sameAs staatskalender:20050577 .
-
-systemmap:ORG208 a systemmap:FederalOrganization ;
-    rdfs:label "Bildung & Forschung"@de ;
-    schema:parentOrganization systemmap:ORG201 ;
-    owl:sameAs staatskalender:20035170 .
-
-systemmap:ORG210 a systemmap:FederalOrganization ;
+systemmap:QFKPRpdGa5UISiJlx a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Zoll und Grenzsicherheit"@de,
         "Federal Office for Customs and Border Security"@en,
         "Office fédéral de la douane et de la sécurité des frontières"@fr,
@@ -2061,34 +1557,112 @@ systemmap:ORG210 a systemmap:FederalOrganization ;
         "OFDF"@fr,
         "UDSC"@it .
 
-systemmap:ORG211 a systemmap:FederalOrganization ;
-    rdfs:label "Bundesamt für Lebensmittelsicherheit und Veterinärwesen"@de,
-        "Federal Food Safety and Veterinary Office"@en,
-        "Office fédéral de la sécurité alimentaire et des affaires vétérinaires"@fr,
-        "Ufficio federale della sicurezza alimentare e di veterinaria"@it ;
+systemmap:QFL2DYxeNnVaFsv64 a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Pflanzengesundheit"@de,
+        "Plant Health Division"@en,
+        "Secteur santé des végétaux"@fr,
+        "Settore salute delle piante"@it ;
+    schema:parentOrganization systemmap:QzXI1C2DYjDriK2F8 ;
     rdfs:comment """  
-        Hauptaufgabe des BLV ist es, die Gesundheit und das Wohlbefinden von Mensch und Tier aktiv zu fördern.  
-        Die Hauptpfeiler dafür sind beim Menschen Lebensmittelsicherheit und gesunde Ernährung und beim Tier Tierschutz und Tiergesundheit.  
+        Die Aufgabe des Fachbereiches Pflanzengesundheit (FBPG) ist es, die Einschleppung und Ausbreitung von (geregelten) besonders gefährlichen Schädlingen und Krankheiten von Pflanzen zu vermeiden.  
+        Dies ist wichtig, um wirtschaftliche, soziale und ökologische Schäden zu vermeiden.  
+        Der Eidgenössische Pflanzenschutzdienst (EPSD), der vom Fachbereich gemeinsam mit der Sektion Waldschutz und Waldgesundheit des Bundesamts für Umwelt (BAFU) geführt wird, ist für die Umsetzung dieser Aufgabe auf nationaler Ebene zuständig.  
         """@de,
         """  
-        The main task of the FSVO is to actively promote the health and well-being of humans and animals.  
-        The key pillars for this are food safety and healthy nutrition for humans, and animal welfare and health for animals.  
+        The task of the Plant Health Division (FBPG) is to prevent the introduction and spread of (regulated) particularly dangerous plant pests and diseases.  
+        This is important to avoid economic, social, and environmental damage.  
+        The Swiss Plant Protection Service (EPSD), managed jointly by the division and the Forest Protection and Health Section of the Federal Office for the Environment (FOEN), is responsible for implementing this task at the national level.  
         """@en,
         """  
-        La principale mission de l'OSAV est de promouvoir activement la santé et le bien-être des humains et des animaux.  
-        Les piliers essentiels sont la sécurité alimentaire et une alimentation saine pour les humains, ainsi que la protection et la santé des animaux.  
+        La mission du secteur santé des végétaux (FBPG) est d'éviter l'introduction et la propagation de ravageurs et de maladies des plantes particulièrement dangereux (réglementés).  
+        Cela est essentiel pour prévenir des dommages économiques, sociaux et environnementaux.  
+        Le Service fédéral de la protection des végétaux (EPSD), géré conjointement par le secteur et la section Protection et santé des forêts de l'Office fédéral de l'environnement (OFEV), est responsable de la mise en œuvre de cette mission au niveau national.  
         """@fr,
         """  
-        Il compito principale dell'USAV è promuovere attivamente la salute e il benessere di esseri umani e animali.  
-        I pilastri principali sono la sicurezza alimentare e un'alimentazione sana per gli esseri umani, nonché il benessere e la salute degli animali.  
+        Il compito del settore salute delle piante (FBPG) è prevenire l'introduzione e la diffusione di parassiti e malattie delle piante particolarmente pericolosi (regolamentati).  
+        Questo è fondamentale per evitare danni economici, sociali e ambientali.  
+        Il Servizio fitosanitario federale (EPSD), gestito congiuntamente dal settore e dalla Sezione protezione e salute delle foreste dell'Ufficio federale dell'ambiente (UFAM), è responsabile dell'attuazione di questo compito a livello nazionale.  
         """@it ;
-    owl:sameAs staatskalender:10008671 ;
-    systemmap:abbreviation "BLV"@de,
-        "FSVO"@en,
-        "OSAV"@fr,
-        "USAV"@it .
+    systemmap:abbreviation "FBPG"@de,
+        "FBPG"@en,
+        "FBPG"@fr,
+        "FBPG"@it .
 
-systemmap:ORG212 a systemmap:FederalOrganization ;
+systemmap:QG8fSveeGZNcYzoUN a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Meliorationen"@de ;
+    schema:parentOrganization systemmap:QsJ9OfSkUgPD8dkz3 ;
+    rdfs:comment """
+        Der Fachbereich Meliorationen ist in der Verbundaufgabe mit den Kantonen im ländlichen Tiefbau (Bodenverbesserungen) tätig.
+        Er ist bundesintern verfahrensleitende Behörde, beurteilt die Gesuche und übt die Oberaufsicht aus.
+        Zudem behandelt er Fragen der Raumplanung und der Infrastrukturen.
+        Weitere Themen sind Management natürlicher Ressourcen, Klimawandel mit Blick auf Boden/Wasserhaushalt.
+        """@de .
+
+systemmap:QIo1a8l3IT4lBqBJE a systemmap:FederalOrganization ;
+    rdfs:label "Agroscope"@de,
+        "Agroscope"@en,
+        "Agroscope"@fr,
+        "Agroscope"@it ;
+    schema:parentOrganization systemmap:Q2tIdqNmt3uS5Ny6D ;
+    rdfs:comment """
+        Agroscope ist das Schweizer Kompetenzzentrum für landwirtschaftliche Forschung und engagiert sich für eine nachhaltige Landwirtschaft, hochwertige Lebensmittelproduktion und Umweltschutz.
+        Angeschlossen an das Bundesamt für Landwirtschaft, forscht es entlang der gesamten Wertschöpfungskette der Landwirtschafts- und Ernährungsbranche, von Pflanzenbau und Nutztierhaltung bis hin zu Lebensmitteln und Ernährung.
+        Neben der Forschung bietet Agroscope Politikberatung, Wissensaustausch und Technologietransfer, um ein wettbewerbsfähiges und multifunktionales Agrar- und Ernährungssystem in der Schweiz zu unterstützen.
+        """@de,
+        """
+        Agroscope is the Swiss centre of excellence for agricultural research, dedicated to advancing sustainable agriculture, high-quality food production, and environmental protection .
+        Affiliated with the Federal Office for Agriculture, it conducts research along the entire value chain of the agriculture and food sector, covering topics from plant production and livestock to food and nutrition .
+        In addition to research, Agroscope provides policy advice, knowledge exchange, and technology transfer to support a competitive and multifunctional agri-food system in Switzerland .
+        """@en,
+        """
+        Agroscope est le centre de compétence suisse pour la recherche agricole, dédié à l’agriculture durable, à la production alimentaire de qualité et à la protection de l’environnement.
+        Rattaché à l’Office fédéral de l’agriculture, il mène des recherches tout au long de la chaîne de valeur du secteur agricole et alimentaire, couvrant des sujets allant de la production végétale et de l’élevage à l’alimentation et la nutrition.
+        En plus de la recherche, Agroscope fournit des conseils politiques, des échanges de connaissances et un transfert de technologies pour soutenir un système agroalimentaire compétitif et multifonctionnel en Suisse.
+        """@fr,
+        """
+        Agroscope è il centro di competenza svizzero per la ricerca agricola, impegnato nell'agricoltura sostenibile, nella produzione alimentare di alta qualità e nella protezione ambientale.
+        Affiliato all'Ufficio federale dell'agricoltura, conduce ricerche lungo l'intera catena del valore del settore agricolo e alimentare, coprendo argomenti che vanno dalla produzione vegetale e dall'allevamento fino agli alimenti e alla nutrizione.
+        Oltre alla ricerca, Agroscope fornisce consulenza politica, scambio di conoscenze e trasferimento tecnologico per sostenere un sistema agroalimentare competitivo e multifunzionale in Svizzera.
+        """@it ;
+    owl:sameAs staatskalender:10003634 .
+
+systemmap:QMnIieexlpOQHsGvN a systemmap:FederalOrganization ;
+    rdfs:label "Genetische Ressourcen, Produktionssicherheit und Futtermittel"@de,
+        "Genetic Resources, Production Safety and Animal Feed"@en,
+        "Ressources génétiques, sécurité de la production et aliments pour animaux"@fr,
+        "Risorse genetiche, sicurezza della produzione e mangimi"@it ;
+    schema:parentOrganization systemmap:QzXI1C2DYjDriK2F8 ;
+    rdfs:comment """  
+        Der Fachbereich Genetische Ressourcen, Produktionssicherheit und Futtermittel ist verantwortlich für den Erhalt und die nachhaltige Nutzung pflanzengenetischer Ressourcen,  
+        die Überwachung der Gentechnologie in der Landwirtschaft sowie die Identifikation und Regulierung von Risiken in der landwirtschaftlichen Produktion.  
+        Zudem übernimmt er das Ereignis- und Krisenmanagement bei ABCN-Ereignissen und koordiniert die Futtermittelkontrolle sowie die Weiterentwicklung der entsprechenden Verordnungen.  
+        Ein weiterer Schwerpunkt liegt auf der Tiergesundheit, insbesondere durch die Förderung von Innovationen, Antibiotikaresistenzstrategien und den One-Health-Ansatz.  
+        """@de,
+        """  
+        The Genetic Resources, Production Safety and Animal Feed Division is responsible for the conservation and sustainable use of plant genetic resources,  
+        the monitoring of agricultural biotechnology, and the identification and regulation of risks in agricultural production.  
+        It also manages incident and crisis response for ABCN events and coordinates animal feed control and the development of relevant regulations.  
+        Another focus is on animal health, particularly through the promotion of innovations, antibiotic resistance strategies, and the One Health approach.  
+        """@en,
+        """  
+        Le secteur Ressources génétiques, sécurité de la production et aliments pour animaux est responsable de la conservation et de l'utilisation durable des ressources génétiques végétales,  
+        de la surveillance de la biotechnologie agricole et de l'identification et de la régulation des risques dans la production agricole.  
+        Il gère également la réponse aux incidents et aux crises en cas d’événements ABCN et coordonne le contrôle des aliments pour animaux ainsi que l'évolution des réglementations correspondantes.  
+        Un autre axe majeur concerne la santé animale, notamment à travers la promotion des innovations, des stratégies de lutte contre la résistance aux antibiotiques et l'approche One Health.  
+        """@fr,
+        """  
+        Il settore Risorse genetiche, sicurezza della produzione e mangimi è responsabile della conservazione e dell’uso sostenibile delle risorse genetiche vegetali,  
+        del monitoraggio delle biotecnologie agricole e dell’identificazione e regolamentazione dei rischi nella produzione agricola.  
+        Inoltre, gestisce la risposta a incidenti e crisi legati a eventi ABCN e coordina il controllo dei mangimi e lo sviluppo delle normative pertinenti.  
+        Un altro punto focale è la salute animale, in particolare attraverso la promozione di innovazioni, strategie contro la resistenza agli antibiotici e l’approccio One Health.  
+        """@it ;
+    owl:sameAs staatskalender:20011808 ;
+    systemmap:abbreviation "FBGRT"@de,
+        "FBGRT"@en,
+        "FBGRT"@fr,
+        "FBGRT"@it .
+
+systemmap:QNbhMvt3Btta1U1d6 a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Statistik"@de,
         "Federal Statistical Office"@en,
         "Office fédéral de la statistique"@fr,
@@ -2115,12 +1689,373 @@ systemmap:ORG212 a systemmap:FederalOrganization ;
         "OFS"@fr,
         "UST"@it .
 
-systemmap:ORG213 a systemmap:FederalOrganization ;
+systemmap:QQbNLiw8h9MnSXuyo a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Informatikführung"@de,
+        "Information Technology Management Division"@en,
+        "Secteur Gestion Informatique"@fr,
+        "Settore Gestione Informatica"@it ;
+    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    rdfs:comment """
+        Der Fachbereich Informatikführung verantwortet die strategische Planung, Umsetzung und Sicherheit der Informatik im BLW, einschliesslich des Managements von Projekten, Budgets und Fachanwendungen.
+        Er fungiert als Schnittstelle zu Dienstleistern, koordiniert Change-Management-Prozesse und stellt die Ausbildung sowie die Verwaltung von Mutationen und Berechtigungen sicher.
+        """@de,
+        """
+        The Information Technology Management Division is responsible for the strategic planning, implementation, and security of IT within the FOAG, including the management of projects, budgets, and specialized applications.
+        It serves as an interface with service providers, coordinates change management processes, and ensures training as well as the administration of modifications and access rights.
+        """@en,
+        """
+        Le Secteur Gestion Informatique est responsable de la planification stratégique, de la mise en œuvre et de la sécurité de l’informatique au sein de l’OFAG, y compris la gestion des projets, des budgets et des applications spécialisées.
+        Il sert d’interface avec les prestataires de services, coordonne les processus de gestion du changement et assure la formation ainsi que l’administration des modifications et des droits d’accès.
+        """@fr,
+        """
+        Il Settore Gestione Informatica è responsabile della pianificazione strategica, dell’attuazione e della sicurezza dell’informatica all’interno dell’UFAG, compresa la gestione di progetti, budget e applicazioni specializzate.
+        Funziona come interfaccia con i fornitori di servizi, coordina i processi di gestione del cambiamento e garantisce la formazione nonché l’amministrazione delle modifiche e dei diritti di accesso.
+        """@it ;
+    owl:sameAs staatskalender:10003237 ;
+    systemmap:abbreviation "FBIF"@de,
+        "ITMD"@en,
+        "SGI"@fr,
+        "SGI"@it .
+
+systemmap:QRu4rav1Rlm2mUMWr a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Ein- und Ausfuhr"@de,
+        "Specialized Unit for Import and Export"@en,
+        "Secteur Importations et exportations"@fr,
+        "Settore Importazioni ed esportazioni"@it ;
+    schema:parentOrganization systemmap:QhkERubSSrICbOshu ;
+    rdfs:comment """
+        Zu den Hauptaufgaben des Fachbereichs Ein- und Ausfuhr (FBEA) gehören die Verwaltung der Zollkontingente, die Erteilung von Einfuhrbewilligungen, die Zuteilung von Kontingentsanteilen, die Koordination mit der Oberzolldirektion sowie die Durchführung von internen und externen Kontrollen.
+        Zudem kümmert sich der FBEA um die Gebührenverwaltung, den Betrieb und die Wartung von Fachapplikationen, die Bearbeitung von Gesuchen im Veredelungsverkehr und um Exportberatungen.
+        """@de,
+        """
+        The main tasks of the Specialized Unit for Import and Export (FBEA) include the management of tariff quotas, the issuance of import permits, the allocation of quota shares, coordination with the Federal Customs Directorate, and the execution of internal and external controls.
+        Additionally, the FBEA handles fee management, the operation and maintenance of specialized applications, the processing of applications for inward processing, and export consulting.
+        """@en,
+        """
+        Les principales tâches de l'Unité spécialisée Importation et Exportation (FBEA) comprennent la gestion des contingents tarifaires, la délivrance des autorisations d'importation, l'attribution des parts de contingent, la coordination avec la Direction générale des douanes et l'exécution des contrôles internes et externes.
+        De plus, le FBEA s'occupe de la gestion des taxes, de l'exploitation et de la maintenance des applications spécialisées, du traitement des demandes dans le cadre du perfectionnement actif et du conseil en exportation.
+        """@fr,
+        """
+        I principali compiti dell'Unità specializzata Importazione ed Esportazione (FBEA) comprendono la gestione delle contingenti tariffari, il rilascio delle autorizzazioni all'importazione, l'assegnazione delle quote di contingente, il coordinamento con la Direzione Generale delle Dogane e l'esecuzione di controlli interni ed esterni.
+        Inoltre, il FBEA si occupa della gestione delle tasse, del funzionamento e della manutenzione delle applicazioni specializzate, dell'elaborazione delle domande nel traffico di perfezionamento attivo e della consulenza all'esportazione.
+        """@it ;
+    owl:sameAs staatskalender:10003223 ;
+    systemmap:abbreviation "FBEA"@de,
+        "SIE"@fr .
+
+systemmap:QW5qcGjvfz5WXYTVl a systemmap:FederalOrganization ;
+    rdfs:label "Abteilung Lebensmittel und Ernährung"@de,
+        "Food and Nutrition Division"@en,
+        "Département denrées alimentaires et nutrition"@fr,
+        "Dipartimento alimenti e nutrizione"@it ;
+    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    rdfs:comment """
+        Die Abteilung Lebensmittel und Ernährung des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) ist verantwortlich für die Sicherheit und Qualität von Lebensmitteln sowie die Förderung einer gesunden Ernährung.
+        Sie entwickelt Richtlinien und überwacht die Einhaltung von Standards, um die Gesundheit der Bevölkerung zu schützen.
+        Zudem informiert sie die Öffentlichkeit über ernährungsrelevante Themen und arbeitet mit nationalen sowie internationalen Partnern zusammen.
+        """@de,
+        """
+        The Food and Nutrition Division of the Federal Food Safety and Veterinary Office (FSVO) is responsible for the safety and quality of food products, as well as promoting healthy nutrition.
+        It develops guidelines and monitors compliance with standards to protect public health.
+        Additionally, it informs the public about nutritional issues and collaborates with national and international partners.
+        """@en,
+        """
+        Le Département denrées alimentaires et nutrition de l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) est responsable de la sécurité et de la qualité des denrées alimentaires ainsi que de la promotion d'une alimentation saine.
+        Il élabore des directives et surveille le respect des normes afin de protéger la santé de la population.
+        De plus, il informe le public sur les questions nutritionnelles et collabore avec des partenaires nationaux et internationaux.
+        """@fr,
+        """
+        Il Dipartimento alimenti e nutrizione dell'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) è responsabile della sicurezza e della qualità degli alimenti, nonché della promozione di una sana alimentazione.
+        Sviluppa linee guida e monitora il rispetto degli standard per proteggere la salute della popolazione.
+        Inoltre, informa il pubblico su temi nutrizionali e collabora con partner nazionali e internazionali.
+        """@it ;
+    owl:sameAs staatskalender:20035162 .
+
+systemmap:QaVyVVsIDkiDMtQq4 a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Marktanalyse"@de,
+        "Market Analysis Division"@en,
+        "Secteur analyses du marché"@fr,
+        "Settore analisi di mercato"@it ;
+    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    rdfs:comment """
+        Der Fachbereich Marktanalysen informiert regelmässig über die Preisentwicklung in den Agrarmärkten mit dem Ziel, die Markttransparenz zu erhöhen und langfristige Entwicklungen aufzuzeigen.
+        Dazu werden in verschiedenen Marktbereichen Preise entlang der Wertschöpfungsketten erhoben und ausgewiesen sowie datengestützte Marktanalysen erstellt.
+        """@de,
+        """
+        The Market Analysis Division regularly provides information on price developments in agricultural markets with the aim of increasing market transparency and highlighting long-term trends.
+        To this end, prices are collected and reported along the value chains in various market sectors, and data-driven market analyses are created.
+        """@en,
+        """
+        Le Secteur analyses du marché informe régulièrement sur l'évolution des prix sur les marchés agricoles dans le but d'accroître la transparence du marché et de mettre en évidence les tendances à long terme.
+        À cette fin, les prix sont collectés et publiés tout au long des chaînes de valeur dans divers secteurs du marché, et des analyses de marché basées sur les données sont élaborées.
+        """@fr,
+        """
+        Il Settore analisi di mercato informa regolarmente sull'andamento dei prezzi nei mercati agricoli con l'obiettivo di aumentare la trasparenza del mercato e evidenziare le tendenze a lungo termine.
+        A tal fine, i prezzi vengono raccolti e riportati lungo le catene del valore in vari settori di mercato e vengono create analisi di mercato basate sui dati.
+        """@it ;
+    systemmap:abbreviation "FBMA"@de,
+        "MAD"@en,
+        "SAM"@fr,
+        "SAM"@it ;
+    systemmap:hasLegalBasis LwG:art_27,
+        <https://www.fedlex.admin.ch/eli/cc/1999/71> .
+
+systemmap:QcVJ3tNOuwZ1juXuE a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Tierische Produkte und Tierzucht"@de,
+        "Sector Animal Products and Breeding"@en,
+        "Secteur Produits animaux et élevage"@fr,
+        "Settore Prodotti animali e allevamento"@it ;
+    schema:parentOrganization systemmap:QhkERubSSrICbOshu ;
+    rdfs:comment "Die Mitgestaltung der agrarpolitischen Rahmenbedingungen und deren Weiterentwicklung im Bereich der tierischen Produkte und der Tierzucht gehören zu den Kernaufgaben des FBTT. Weiter stellt er den reibungslosen und korrekten Vollzug der einschlägigen Bestimmungen des Landwirtschaftsgesetzes und folgender Bundesratsverordnungen sicher: Milchpreisstützungsverordnung, Schlachtviehverordnung, Eierverordnung, Verordnung über die Identitas AG und die Tierverkehrsdatenbank, Entsorgungsbeitragsverordnung, Landwirtschaftliche Deklarationsverordnung, Höchstbestandesverordnung, Verordnung über die Branchen- und Produzentenorganisationen, Schafwollverordnung und Tierzuchtverordnung."@de,
+        "The design and further development of agricultural policy framework conditions in the field of animal products and breeding are among the core tasks of the SPAE. Furthermore, it ensures the smooth and correct implementation of the relevant provisions of the Agricultural Act and the following Federal Council ordinances: Milk Price Support Ordinance, Slaughter Livestock Ordinance, Egg Ordinance, Ordinance on Identitas AG and the Animal Traffic Database, Disposal Contribution Ordinance, Agricultural Declaration Ordinance, Maximum Stock Ordinance, Ordinance on Sector and Producer Organizations, Sheep Wool Ordinance, and Breeding Ordinance."@en,
+        "La conception et le développement des cadres politiques agricoles dans le domaine des produits animaux et de l'élevage font partie des missions principales du SPAE. Il veille également à la mise en œuvre correcte et sans heurts des dispositions pertinentes de la loi agricole et des ordonnances suivantes du Conseil fédéral : Ordonnance sur le soutien des prix du lait, Ordonnance sur le bétail de boucherie, Ordonnance sur les œufs, Ordonnance sur Identitas AG et la base de données sur le trafic des animaux, Ordonnance sur la contribution à l'élimination, Ordonnance sur la déclaration agricole, Ordonnance sur le nombre maximal d'animaux, Ordonnance sur les organisations de filières et de producteurs, Ordonnance sur la laine de mouton et Ordonnance sur l'élevage."@fr,
+        "La progettazione e lo sviluppo del quadro politico agricolo nel settore dei prodotti animali e dell'allevamento sono tra i compiti principali dello SPAA. Inoltre, garantisce l'attuazione fluida e corretta delle disposizioni pertinenti della legge sull'agricoltura e delle seguenti ordinanze del Consiglio federale: Ordinanza sul sostegno del prezzo del latte, Ordinanza sul bestiame da macello, Ordinanza sulle uova, Ordinanza su Identitas AG e la banca dati sul traffico degli animali, Ordinanza sul contributo per lo smaltimento, Ordinanza sulla dichiarazione agricola, Ordinanza sul numero massimo di capi, Ordinanza sulle organizzazioni di settore e di produttori, Ordinanza sulla lana di pecora e Ordinanza sulla selezione degli animali."@it ;
+    owl:sameAs staatskalender:10003217 ;
+    systemmap:abbreviation "FBTT"@de,
+        "FBTT"@en,
+        "SPAE"@fr,
+        "SPAA"@it ;
+    systemmap:access systemmap:QLXw4VofhYbzXVNKC,
+        systemmap:Qe6Nt3cqogxz2d10g,
+        systemmap:QoY82Q0qEk9k0s3w3,
+        systemmap:Qutd0KIj3Rf8GlSwq .
+
+systemmap:QcoeXHl4TgJbke1Yf a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Direktzahlungsgrundlagen"@de,
+        "Direct Payment Principles Division"@en,
+        "Secteur bases des paiements directs"@fr,
+        "Settore basi dei pagamenti diretti"@it ;
+    schema:parentOrganization systemmap:QsJ9OfSkUgPD8dkz3 ;
+    rdfs:comment """  
+        Der Fachbereich Direktzahlungsgrundlagen ist zuständig für die Umsetzung und Weiterentwicklung des Direktzahlungssystems im Bereich der Versorgungssicherheit,  
+        der Kulturlandschaft, der Übergangsbeiträge, der landwirtschaftlichen Zonen und Gebiete, der landwirtschaftlichen Begriffe sowie der Anerkennung von Betrieben und Betriebsformen.  
+        """@de,
+        """  
+        The Direct Payment Principles Division is responsible for implementing and further developing the direct payment system  
+        in the areas of food security, cultural landscape, transitional payments, agricultural zones and areas, agricultural terminology,  
+        and the recognition of farms and farming models.  
+        """@en,
+        """  
+        Le secteur bases des paiements directs est responsable de la mise en œuvre et du développement du système des paiements directs  
+        dans les domaines de la sécurité de l'approvisionnement, du paysage culturel, des contributions transitoires,  
+        des zones et régions agricoles, de la terminologie agricole ainsi que de la reconnaissance des exploitations et des modèles d’exploitation.  
+        """@fr,
+        """  
+        Il settore basi dei pagamenti diretti è responsabile dell'attuazione e dello sviluppo del sistema dei pagamenti diretti  
+        nei settori della sicurezza dell'approvvigionamento, del paesaggio culturale, dei contributi transitori,  
+        delle zone e aree agricole, della terminologia agricola e del riconoscimento delle aziende e dei modelli aziendali.  
+        """@it ;
+    owl:sameAs staatskalender:10003228 ;
+    systemmap:abbreviation "FBDG"@de,
+        "FBDG"@en,
+        "FBDG"@fr,
+        "FBDG"@it .
+
+systemmap:QfX7h09MplFWwb4LK a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich nachhaltiger Pflanzenschutz und Sorten"@de,
+        "Sustainable Plant Protection and Varieties Division"@en,
+        "Secteur protection durable des végétaux et variétés"@fr,
+        "Settore protezione sostenibile delle piante e varietà"@it ;
+    schema:parentOrganization systemmap:QzXI1C2DYjDriK2F8 ;
+    rdfs:comment """  
+        Der Fachbereich nachhaltiger Pflanzenschutz und Sorten (FB NPS) sorgt für den Schutz der Kulturen, den Vollzug des Saatgutrechtes und den Sortenschutz.  
+        Dabei werden sowohl präventive als auch direkte Pflanzenschutzmassnahmen angewendet, um hochwertige Lebensmittel zu produzieren.  
+        Zudem ist das BLW für die Weiterentwicklung der Verordnungen zu Vermehrungsmaterial, den Nationalen Sortenkatalog und den Vollzug der Bestimmungen in Zusammenarbeit mit Agroscope verantwortlich.  
+        """@de,
+        """  
+        The Sustainable Plant Protection and Varieties Division (FBNPS) ensures crop protection, enforces seed law, and manages variety protection.  
+        Both preventive and direct plant protection measures are applied to produce high-quality food.  
+        Additionally, the FOAG is responsible for developing regulations on propagation material, maintaining the National Variety Catalogue, and enforcing regulations in collaboration with Agroscope.  
+        """@en,
+        """  
+        Le secteur protection durable des végétaux et variétés (FBNPS) assure la protection des cultures, l'application du droit des semences et la protection des variétés.  
+        Des mesures de protection des plantes, tant préventives que directes, sont mises en œuvre pour produire des denrées alimentaires de haute qualité.  
+        De plus, l'OFAG est responsable du développement des réglementations sur le matériel de multiplication, du catalogue national des variétés et de l'application des dispositions en collaboration avec Agroscope.  
+        """@fr,
+        """  
+        Il settore protezione sostenibile delle piante e varietà (FBNPS) garantisce la protezione delle colture, l'applicazione della legislazione sulle sementi e la tutela delle varietà.  
+        Vengono applicate misure di protezione delle piante sia preventive che dirette per produrre alimenti di alta qualità.  
+        Inoltre, l'UFAG è responsabile dello sviluppo delle normative sul materiale di propagazione, del catalogo nazionale delle varietà e dell'applicazione delle disposizioni in collaborazione con Agroscope.  
+        """@it ;
+    systemmap:abbreviation "FBNPS"@de,
+        "FBNPS"@en,
+        "FBNPS"@fr,
+        "FBNPS"@it .
+
+systemmap:Qg6T9dU4npL98bHrb a systemmap:FederalOrganization ;
+    rdfs:label "Abteilung Tiergesundheit und Tierschutz"@de,
+        "Animal Health and Welfare Division"@en,
+        "Département de la santé et de la protection des animaux"@fr,
+        "Dipartimento della salute e della protezione degli animali"@it ;
+    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    rdfs:comment """
+        Die Abteilung Tiergesundheit und Tierschutz des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) fördert die Gesundheit und das Wohlbefinden von Tieren.
+        Sie arbeitet eng mit Tierhalterorganisationen und Vollzugsorganen zusammen, basierend auf wissenschaftlichen Grundlagen.
+        Die Abteilung ist in sechs Fachbereiche unterteilt: Tierseuchenprävention, Tierseuchenbekämpfung, Tierarzneimittel, Nutztierhaltung, Tierschutz Haus- und Wildtiere sowie Tierversuche.
+        """@de,
+        """
+        The Animal Health and Welfare Division of the Federal Food Safety and Veterinary Office (FSVO) promotes the health and well-being of animals.
+        It collaborates closely with animal owner organizations and enforcement bodies, based on scientific foundations.
+        The division is divided into six specialized areas: epizootic disease prevention, epizootic disease control, veterinary medicines, livestock farming, protection of domestic and wild animals, and animal experimentation.
+        """@en,
+        """
+        Le Département de la santé et de la protection des animaux de l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) promeut la santé et le bien-être des animaux.
+        Il collabore étroitement avec les organisations d'éleveurs et les organes d'exécution, en s'appuyant sur des bases scientifiques.
+        Le département est divisé en six domaines spécialisés : prévention des épizooties, lutte contre les épizooties, médicaments vétérinaires, élevage des animaux de rente, protection des animaux domestiques et sauvages, ainsi que les expériences sur animaux.
+        """@fr,
+        """
+        Il Dipartimento della salute e della protezione degli animali dell'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) promuove la salute e il benessere degli animali.
+        Collabora strettamente con le organizzazioni di allevatori e gli organi di esecuzione, basandosi su fondamenti scientifici.
+        Il dipartimento è suddiviso in sei settori specialistici: prevenzione delle epizoozie, lotta contro le epizoozie, medicinali veterinari, allevamento degli animali da reddito, protezione degli animali domestici e selvatici, nonché sperimentazione animale.
+        """@it ;
+    owl:sameAs staatskalender:20035164 .
+
+systemmap:QhkERubSSrICbOshu a systemmap:FederalOrganization ;
+    rdfs:label "Direktionsbereich Märkte und Internationales"@de,
+        "Directorate for Markets and International Affairs"@en,
+        "Unité de direction Marchés et affaires internationales"@fr,
+        "Unità di direzione Mercati e affari internazionali"@it ;
+    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    rdfs:comment "Der Direktionsbereich Märkte und Internationales setzt sich dafür ein, dass die Landwirtschaft aus dem Verkauf ihrer Produkte eine möglichst hohe Wertschöpfung erzielen kann. Selbsthilfemassnahmen, Innovation und Vermarktung der verschiedenen Branchen werden unterstützt. Zudem engagiert sich dieser Direktionsbereich in internationalen Organisationen wie der UNO-Ernährungsorganisation FAO oder der Welthandelsorganisation WTO."@de,
+        "The Directorate for Markets and International Affairs works to ensure that agriculture achieves the highest possible added value from the sale of its products. It supports self-help measures, innovation, and the marketing of various sectors. Additionally, this directorate is involved in international organizations such as the UN Food and Agriculture Organization (FAO) and the World Trade Organization (WTO)."@en,
+        "La Direction des marchés et des affaires internationales s'efforce de garantir que l'agriculture tire la plus grande valeur ajoutée possible de la vente de ses produits. Elle soutient les mesures d'auto-assistance, l'innovation et la commercialisation des différentes filières. De plus, cette direction est impliquée dans des organisations internationales telles que l'Organisation des Nations unies pour l'alimentation et l'agriculture (FAO) et l'Organisation mondiale du commerce (OMC)."@fr,
+        "La Direzione dei mercati e degli affari internazionali si adopera affinché l'agricoltura ottenga il massimo valore aggiunto possibile dalla vendita dei suoi prodotti. Sostiene misure di auto-aiuto, innovazione e commercializzazione nei vari settori. Inoltre, questa direzione è coinvolta in organizzazioni internazionali come l'Organizzazione delle Nazioni Unite per l'alimentazione e l'agricoltura (FAO) e l'Organizzazione mondiale del commercio (OMC)."@it ;
+    systemmap:abbreviation "DBMI"@de .
+
+systemmap:QieZtzwlMAxzFY1op a systemmap:FederalOrganization ;
+    rdfs:label "Business Intelligence Competence Center"@de,
+        "Business Intelligence Competence Center"@en,
+        "Centre de compétence Business Intelligence"@fr,
+        "Centro di competenza Business Intelligence"@it ;
+    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    rdfs:comment """  
+        Das Business Intelligence Competence Center (BI) ist verantwortlich für die Entwicklung und Umsetzung der BI-Strategie sowie die Planung und Durchführung von BI-Projekten.  
+        Zu seinen Aufgaben gehören die Datenvisualisierung, das Reporting, die Beratung und Schulung von BI-Fachanwendern sowie die Analyse, Modellierung und Integration von Daten.  
+        Zudem koordiniert das BI-Team den Betrieb von ASTAT mit dem ISCeco und die BI-Aktivitäten mit dem BLV.  
+        """@de,
+        """  
+        The Business Intelligence Competence Center (BI) is responsible for developing and implementing the BI strategy, as well as planning and executing BI projects.  
+        Its tasks include data visualization, reporting, advising and training BI professionals, as well as data analysis, modeling, and integration.  
+        Additionally, the BI team coordinates the operation of ASTAT with ISCeco and BI activities with the FSVO.  
+        """@en,
+        """  
+        Le Centre de compétence Business Intelligence (BI) est responsable du développement et de la mise en œuvre de la stratégie BI, ainsi que de la planification et de l'exécution des projets BI.  
+        Ses tâches incluent la visualisation des données, le reporting, le conseil et la formation des spécialistes BI, ainsi que l'analyse, la modélisation et l'intégration des données.  
+        De plus, l'équipe BI coordonne l'exploitation d'ASTAT avec l'ISCeco et les activités BI avec l'OSAV.  
+        """@fr,
+        """  
+        Il Centro di competenza Business Intelligence (BI) è responsabile dello sviluppo e dell'implementazione della strategia BI, nonché della pianificazione e dell'esecuzione dei progetti BI.  
+        I suoi compiti includono la visualizzazione dei dati, il reporting, la consulenza e la formazione degli specialisti BI, oltre all'analisi, alla modellazione e all'integrazione dei dati.  
+        Inoltre, il team BI coordina il funzionamento di ASTAT con ISCeco e le attività BI con l'USAV.  
+        """@it ;
+    systemmap:abbreviation "GRBI"@de,
+        "GRBI"@en,
+        "GRBI"@fr,
+        "GRBI"@it .
+
+systemmap:QntetIp00hrUGsnj5 a systemmap:FederalOrganization ;
+    rdfs:label "Direktionsbereich Recht, Ressourcen und Integrale Sicherheit"@de,
+        "Directorate for Law, Resources, and Integral Security"@en,
+        "Unité de direction Droit, ressources internes et sécurité intégrale"@fr,
+        "Unità di direzione Digitalizzazione e gestione dei dati"@it ;
+    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    rdfs:comment "Der Direktionsbereich Recht, Ressourcen und Integrale Sicherheit sichert die rechtliche Konformität der verschiedenen BLW-Massnahmen und ist insbesondere für die personellen Massnahmen des Amtes verantwortlich."@de,
+        "The Directorate for Law, Resources, and Integral Security ensures the legal compliance of various BLW measures and is particularly responsible for the office’s personnel measures."@en,
+        "La Direction du droit, des ressources et de la sécurité intégrale garantit la conformité juridique des différentes mesures de l'OFAG et est notamment responsable des mesures en matière de personnel du bureau."@fr,
+        "La Direzione per il diritto, le risorse e la sicurezza integrale garantisce la conformità legale delle varie misure dell'UFAG ed è in particolare responsabile delle misure relative al personale dell'ufficio."@it ;
+    systemmap:abbreviation "DBRRIS"@de,
+        "DBRRIS"@en,
+        "DBRRIS"@fr,
+        "DBRRIS"@it .
+
+systemmap:QoqmfoevPVgr3d0AA a systemmap:FederalOrganization ;
+    rdfs:label "Zulassungsstelle Pflanzenschutzmittel"@de,
+        "Plant Protection Products Registration Authority"@en,
+        "Autorité d'homologation des produits phytosanitaires"@fr,
+        "Autorità di omologazione dei prodotti fitosanitari"@it ;
+    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    rdfs:comment """
+        Die Zulassungsstelle Pflanzenschutzmittel des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) ist für die Zulassung und Überprüfung von Pflanzenschutzmitteln in der Schweiz verantwortlich.
+        Sie stellt sicher, dass nur sichere und wirksame Pflanzenschutzmittel auf den Markt gelangen, indem sie deren gesundheitliche und ökologische Auswirkungen sorgfältig bewertet.
+        Seit dem 1. Januar 2022 liegt die Zuständigkeit für die Zulassung von Pflanzenschutzmitteln beim BLV, während das Bundesamt für Umwelt (BAFU) die Hauptverantwortung für die Beurteilung der Umweltrisiken übernimmt.
+        """@de,
+        """
+        The Plant Protection Products Registration Authority of the Federal Food Safety and Veterinary Office (FSVO) is responsible for the authorization and review of plant protection products in Switzerland.
+        It ensures that only safe and effective products are placed on the market by carefully evaluating their health and ecological impacts.
+        Since January 1, 2022, the responsibility for the authorization of plant protection products lies with the FSVO, while the Federal Office for the Environment (FOEN) assumes primary responsibility for assessing environmental risks.
+        """@en,
+        """
+        L'Autorité d'homologation des produits phytosanitaires de l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) est responsable de l'autorisation et de la révision des produits phytosanitaires en Suisse.
+        Elle veille à ce que seuls des produits sûrs et efficaces soient mis sur le marché en évaluant soigneusement leurs impacts sanitaires et écologiques.
+        Depuis le 1er janvier 2022, la compétence pour l'autorisation des produits phytosanitaires relève de l'OSAV, tandis que l'Office fédéral de l'environnement (OFEV) assume la responsabilité principale de l'évaluation des risques environnementaux.
+        """@fr,
+        """
+        L'Autorità di omologazione dei prodotti fitosanitari dell'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) è responsabile dell'autorizzazione e della revisione dei prodotti fitosanitari in Svizzera.
+        Garantisce che solo prodotti sicuri ed efficaci siano immessi sul mercato, valutando attentamente i loro impatti sulla salute e sull'ecologia.
+        Dal 1° gennaio 2022, la competenza per l'autorizzazione dei prodotti fitosanitari spetta all'USAV, mentre l'Ufficio federale dell'ambiente (UFAM) ha la responsabilità principale della valutazione dei rischi ambientali.
+        """@it ;
+    owl:sameAs staatskalender:20049676 .
+
+systemmap:Qou0GnQeSqCPHGhze a systemmap:FederalOrganization ;
+    rdfs:label "Abteilung Wissensgrundlagen"@de,
+        "Knowledge Foundations Division"@en,
+        "Département des bases de connaissances"@fr,
+        "Dipartimento delle basi di conoscenza"@it ;
+    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    rdfs:comment """
+        Die Abteilung Wissensgrundlagen unterstützt das Bundesamt für Lebensmittelsicherheit und Veterinärwesen (BLV) durch Förderung der Verfügbarkeit und Nutzung von Daten, Kompetenzen, Verfahren und Wissen.
+        Sie beurteilt gesundheitliche Risiken für Mensch und Tier und stellt sicher, dass der aktuelle Wissensstand erfasst und bei Bedarf durch externe Expertise ergänzt wird.
+        Dadurch werden Risiken frühzeitig erkannt und wissenschaftlich eingeordnet.
+        """@de,
+        """
+        The Knowledge Foundations Division supports the Federal Food Safety and Veterinary Office (FSVO) by promoting the availability and use of data, skills, processes, and knowledge.
+        It assesses health risks to humans and animals and ensures that current knowledge is recorded and supplemented by external expertise when necessary.
+        This enables early identification and scientific classification of risks.
+        """@en,
+        """
+        Le Département des bases de connaissances soutient l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV) en favorisant la disponibilité et l'utilisation des données, compétences, processus et connaissances.
+        Il évalue les risques sanitaires pour l'homme et l'animal et veille à ce que les connaissances actuelles soient recensées et, si nécessaire, complétées par des expertises externes.
+        Ainsi, les risques sont identifiés et classés scientifiquement à un stade précoce.
+        """@fr,
+        """
+        Il Dipartimento delle basi di conoscenza supporta l'Ufficio federale della sicurezza alimentare e di veterinaria (USAV) promuovendo la disponibilità e l'utilizzo di dati, competenze, processi e conoscenze.
+        Valuta i rischi per la salute di uomini e animali e garantisce che le conoscenze attuali siano registrate e, se necessario, integrate da competenze esterne.
+        In questo modo, i rischi possono essere identificati e classificati scientificamente in una fase precoce.
+        """@it ;
+    owl:sameAs staatskalender:20035163 .
+
+systemmap:QqeNr0H0FGL6Uv5Rr a systemmap:FederalOrganization ;
+    rdfs:label "Direktion BLW"@de,
+        "Directorate FOAG"@en,
+        "Direction OFAG"@fr,
+        "Direzione UFAG"@it ;
+    schema:parentOrganization systemmap:Q2tIdqNmt3uS5Ny6D ;
+    owl:sameAs staatskalender:10003196 .
+
+systemmap:QsFdxnjM8hgUdzVT5 a systemmap:FederalOrganization ;
+    rdfs:label "Kompetenzzentrum Daten"@de ;
+    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    owl:sameAs staatskalender:20051877 ;
+    systemmap:abbreviation "DCC"@de .
+
+systemmap:QsJ9OfSkUgPD8dkz3 a systemmap:FederalOrganization ;
+    rdfs:label "Direktionsbereich Direktzahlungen und Ländliche Entwicklung"@de,
+        "Directorate for Direct Payments and Rural Development"@en,
+        "Unité de direction Paiements directs et développement rural"@fr,
+        "Unità di direzione Pagamenti diretti e sviluppo rurale"@it ;
+    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    rdfs:comment "Die Landwirte und Landwirtinnen erbringen verschiedene Leistungen für die Allgemeinheit und werden deshalb mit finanziellen Beiträgen unterstützt. Dafür ist der Direktionsbereich Direktzahlungen und Ländliche Entwicklung zuständig. Er setzt sich zudem für die Vitalität des ländlichen Raums ein."@de,
+        "Farmers provide various services for the general public and are therefore supported with financial contributions. The Directorate for Direct Payments and Rural Development is responsible for this. It also works to ensure the vitality of rural areas."@en,
+        "Les agriculteurs fournissent divers services à la collectivité et sont donc soutenus par des contributions financières. La Direction des paiements directs et du développement rural en est responsable. Elle s'engage également pour la vitalité des zones rurales."@fr,
+        "Gli agricoltori forniscono vari servizi alla collettività e sono quindi sostenuti con contributi finanziari. La Direzione dei pagamenti diretti e dello sviluppo rurale è responsabile di questo. Inoltre, si impegna per la vitalità delle aree rurali."@it ;
+    systemmap:abbreviation "DBDLE"@de .
+
+systemmap:QtL8MElzDJHAjtyXL a systemmap:FederalOrganization ;
     rdfs:label "Gruppe GEVER Services"@de,
         "GEVER Services Group"@en,
         "Groupe Services GEVER"@fr,
         "Gruppo Servizi GEVER"@it ;
-    schema:parentOrganization systemmap:ORG002 ;
+    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
     rdfs:comment """
         Die Gruppe GEVER Services ist für die physische und elektronische Postverteilung sowie die zentrale Adressverwaltung im BLW zuständig.
         Die Postverarbeitung erfolgt hauptsächlich über das GEVER-System, das eine strukturierte Bearbeitung und Archivierung digitaler Unterlagen ermöglicht. 
@@ -2143,33 +2078,98 @@ systemmap:ORG213 a systemmap:FederalOrganization ;
         "GSG"@fr,
         "GSG"@it .
 
-systemmap:ORG214 a systemmap:FederalOrganization ;
-    rdfs:label "Fachbereich Informatikführung"@de,
-        "Information Technology Management Division"@en,
-        "Secteur Gestion Informatique"@fr,
-        "Settore Gestione Informatica"@it ;
-    schema:parentOrganization systemmap:ORG002 ;
+systemmap:QuodJifeNVNW8c4Tj a systemmap:FederalOrganization ;
+    rdfs:label "Bildung & Forschung"@de ;
+    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    owl:sameAs staatskalender:20035170 .
+
+systemmap:QvCD295luQEx4jnuB a systemmap:FederalOrganization ;
+    rdfs:label "Toxikologie Pflanzenschutzmittel"@de ;
+    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    owl:sameAs staatskalender:20035173 .
+
+systemmap:QwlgSr7ukziL6iHsP a systemmap:FederalOrganization ;
+    rdfs:label "Bundesamt für Umwelt"@de,
+        "Federal Office for the Environment"@en,
+        "Office fédéral de l'environnement"@fr,
+        "Ufficio federale dell'ambiente"@it ;
     rdfs:comment """
-        Der Fachbereich Informatikführung verantwortet die strategische Planung, Umsetzung und Sicherheit der Informatik im BLW, einschliesslich des Managements von Projekten, Budgets und Fachanwendungen.
-        Er fungiert als Schnittstelle zu Dienstleistern, koordiniert Change-Management-Prozesse und stellt die Ausbildung sowie die Verwaltung von Mutationen und Berechtigungen sicher.
+        Das Bundesamt für Umwelt (BAFU) ist die Umweltfachstelle der Schweiz und gehört zum Eidgenössischen Departement für Umwelt, Verkehr, Energie und Kommunikation (UVEK).
+        Es ist verantwortlich für die nachhaltige Nutzung der natürlichen Ressourcen sowie den Schutz des Menschen vor Naturgefahren und übermässigen Umweltbelastungen.
+        Gegründet 1971, hat das BAFU seinen Hauptsitz in Bern.
         """@de,
         """
-        The Information Technology Management Division is responsible for the strategic planning, implementation, and security of IT within the FOAG, including the management of projects, budgets, and specialized applications.
-        It serves as an interface with service providers, coordinates change management processes, and ensures training as well as the administration of modifications and access rights.
+        The Federal Office for the Environment (FOEN) is Switzerland's environmental agency and is part of the Federal Department of the Environment, Transport, Energy and Communications (DETEC).
+        It is responsible for the sustainable use of natural resources and the protection of the population from natural hazards and excessive environmental burdens.
+        Founded in 1971, the FOEN is headquartered in Bern.
         """@en,
         """
-        Le Secteur Gestion Informatique est responsable de la planification stratégique, de la mise en œuvre et de la sécurité de l’informatique au sein de l’OFAG, y compris la gestion des projets, des budgets et des applications spécialisées.
-        Il sert d’interface avec les prestataires de services, coordonne les processus de gestion du changement et assure la formation ainsi que l’administration des modifications et des droits d’accès.
+        L'Office fédéral de l'environnement (OFEV) est l'autorité environnementale de la Suisse et fait partie du Département fédéral de l'environnement, des transports, de l'énergie et de la communication (DETEC).
+        Il est responsable de l'utilisation durable des ressources naturelles ainsi que de la protection de la population contre les dangers naturels et les charges environnementales excessives.
+        Fondé en 1971, l'OFEV a son siège principal à Berne.
         """@fr,
         """
-        Il Settore Gestione Informatica è responsabile della pianificazione strategica, dell’attuazione e della sicurezza dell’informatica all’interno dell’UFAG, compresa la gestione di progetti, budget e applicazioni specializzate.
-        Funziona come interfaccia con i fornitori di servizi, coordina i processi di gestione del cambiamento e garantisce la formazione nonché l’amministrazione delle modifiche e dei diritti di accesso.
+        L'Ufficio federale dell'ambiente (UFAM) è l'agenzia ambientale della Svizzera e fa parte del Dipartimento federale dell'ambiente, dei trasporti, dell'energia e delle comunicazioni (DATEC).
+        È responsabile dell'uso sostenibile delle risorse naturali e della protezione della popolazione dai pericoli naturali e dalle eccessive pressioni ambientali.
+        Fondato nel 1971, l'UFAM ha la sua sede principale a Berna.
         """@it ;
-    owl:sameAs staatskalender:10003237 ;
-    systemmap:abbreviation "FBIF"@de,
-        "ITMD"@en,
-        "SGI"@fr,
-        "SGI"@it .
+    owl:sameAs staatskalender:10008758 ;
+    systemmap:abbreviation "BAFU"@de,
+        "FOEN"@en,
+        "OFEV"@fr,
+        "UFAM"@it .
+
+systemmap:QyfZhzeyT1CqJU0BP a systemmap:FederalOrganization ;
+    rdfs:label "Fachbereich Direktzahlungsprogramme"@de,
+        "Direct Payment Programs Division"@en,
+        "Secteur Paiements directs - Programmes"@fr,
+        "Settore Pagamenti diretti - Programmi"@it ;
+    schema:parentOrganization systemmap:QsJ9OfSkUgPD8dkz3 ;
+    rdfs:comment """
+        Der Fachbereich setzt Direktzahlungsprogramme in den Bereichen Umwelt, Tierwohl und Landschaft um, unterstützt kantonale Stellen und überwacht deren Vollzug.  
+        Zudem wird der ökologische Leistungsnachweis (ÖLN) weiterentwickelt, Regelbereiche wie Biodiversitätsstrategie, Biolandbau sowie Energie- und Klimaschutz koordiniert und relevante Gesetzgebungsschnittstellen gepflegt.  
+        Technisch werden EDV-Applikationen bereitgestellt und Kürzungsmassnahmen umgesetzt. Weitere Aufgaben umfassen die Bearbeitung von Stellungnahmen, Öffentlichkeitsarbeit sowie die Information und Einbindung relevanter Akteure.  
+        """@de,
+        """
+        The division implements direct payment programs in the areas of environment, animal welfare, and landscape, supports cantonal authorities, and monitors their enforcement.  
+        Additionally, it develops the ecological performance record (ÖLN), coordinates regulatory areas such as biodiversity strategy, organic farming, and energy and climate protection, and maintains relevant legislative interfaces.  
+        On a technical level, IT applications are provided, and reduction measures are implemented. Other tasks include handling statements, public relations, and informing and involving relevant stakeholders.  
+        """@en,
+        """
+        Le secteur met en œuvre des programmes de paiements directs dans les domaines de l'environnement, du bien-être animal et du paysage, soutient les autorités cantonales et supervise leur application.  
+        De plus, il développe la preuve écologique de performance (ÖLN), coordonne des domaines réglementaires tels que la stratégie de biodiversité, l'agriculture biologique ainsi que la protection de l’énergie et du climat, et entretient les interfaces législatives pertinentes.  
+        Sur le plan technique, des applications informatiques sont mises à disposition et des mesures de réduction sont appliquées. D'autres tâches comprennent le traitement des avis, les relations publiques ainsi que l'information et l'implication des acteurs concernés.  
+        """@fr,
+        """
+        Il settore attua programmi di pagamenti diretti nei settori dell’ambiente, del benessere animale e del paesaggio, supporta le autorità cantonali e ne monitora l’attuazione.  
+        Inoltre, sviluppa la prova delle prestazioni ecologiche (ÖLN), coordina ambiti normativi come la strategia per la biodiversità, l’agricoltura biologica, la protezione dell’energia e del clima e gestisce le interfacce legislative pertinenti.  
+        A livello tecnico, vengono fornite applicazioni informatiche e implementate misure di riduzione. Altri compiti includono la gestione delle dichiarazioni, le relazioni pubbliche e il coinvolgimento degli attori interessati.  
+        """@it ;
+    owl:sameAs staatskalender:10003227 ;
+    systemmap:abbreviation "FBDP"@de,
+        "FBDP"@en,
+        "FBDP"@fr,
+        "FBDP"@it .
+
+systemmap:Qym1u44hA9FMZOdyT a systemmap:FederalOrganization ;
+    rdfs:label "Risikobewertung"@de ;
+    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    owl:sameAs staatskalender:20050577 .
+
+systemmap:QzXI1C2DYjDriK2F8 a systemmap:FederalOrganization ;
+    rdfs:label "Direktionsbereich Produktionsgrundlagen, natürliche Ressourcen und Forschung"@de,
+        "Directorate for Production Resources, Natural Resources and Research"@en,
+        "Unité de direction Bases de production, ressources naturelles et recherche"@fr,
+        "Unità di direzione Basi di produzione, risorse naturali e ricerca"@it ;
+    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    rdfs:comment "Widerstandsfähige Produktions- und Ökosysteme stehen im Zentrum des Direktionsbereichs Produktionsgrundlagen, natürliche Ressourcen und Forschung. So ist er unter anderem dafür zuständig, dass Pflanzen nachhaltig geschützt und Tiere optimal ernährt werden können. Desweitern fördert dieser Bereich verschiedene Forschungs- und Beratungsprojekte in der Schweiz, aber auch international."@de,
+        "Resilient production and ecosystem systems are at the center of the Directorate for Production Resources, Natural Resources and Research. Among other things, it is responsible for ensuring that plants are sustainably protected and animals are optimally fed. Furthermore, this directorate promotes various research and advisory projects in Switzerland and internationally."@en,
+        "Les systèmes de production et les écosystèmes résilients sont au cœur de la Direction des bases de production, des ressources naturelles et de la recherche. Elle est notamment chargée de garantir que les plantes soient protégées durablement et que les animaux soient nourris de manière optimale. De plus, cette direction soutient divers projets de recherche et de conseil en Suisse et à l'international."@fr,
+        "I sistemi produttivi e gli ecosistemi resilienti sono al centro della Direzione delle basi produttive, delle risorse naturali e della ricerca. Tra le altre cose, è responsabile della protezione sostenibile delle piante e dell'alimentazione ottimale degli animali. Inoltre, questa direzione promuove vari progetti di ricerca e consulenza in Svizzera e a livello internazionale."@it ;
+    systemmap:abbreviation "DBPRF"@de,
+        "DBPRF"@en,
+        "DBPRF"@fr,
+        "DBPRF"@it .
 
 staatskalender:20050530 a systemmap:FederalOrganization ;
     rdfs:label "Monitoring des Agrarumweltsystems Schweiz MAUS"@de .
@@ -2245,7 +2245,7 @@ systemmap:INF005 a systemmap:Information ;
         Contiene i dati di identificazione di base degli animali, come i numeri univoci delle marche auricolari, la specie, il sesso e la data di nascita.
         Questi dati principali costituiscono la base per la tracciabilità senza interruzioni nel TVD.
         """@it ;
-    systemmap:containedIn systemmap:SYS020 .
+    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
 
 systemmap:INF006 a systemmap:Information ;
     rdfs:label "Tierereignisdaten"@de,
@@ -2268,7 +2268,7 @@ systemmap:INF006 a systemmap:Information ;
         Registra tutti gli eventi dinamici nel ciclo di vita degli animali, inclusi i dati di nascita, movimento e macellazione, nonché i cambi di detentore.
         Queste informazioni sono essenziali per tracciare i cambi di posizione, le fasi di trasporto e i processi di lavorazione.
         """@it ;
-    systemmap:containedIn systemmap:SYS020 .
+    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
 
 systemmap:INF007 a systemmap:Information ;
     rdfs:label "Meldepflichtdaten (Schafe & Ziegen)"@de,
@@ -2291,7 +2291,7 @@ systemmap:INF007 a systemmap:Information ;
         Contiene dati specifici che devono essere registrati a causa di obblighi di notifica estesi per pecore e capre.
         Ciò include le segnalazioni di nascite (entro 30 giorni), nonché decessi, arrivi e partenze e macellazioni (entro 3 giorni).
         """@it ;
-    systemmap:containedIn systemmap:SYS020 .
+    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
 
 systemmap:INF008 a systemmap:Information ;
     rdfs:label "Daten zu Tierhaltern"@de,
@@ -2318,7 +2318,7 @@ systemmap:INF008 a systemmap:Information ;
         Ciò include i dati di identificazione necessari per l'assegnazione univoca, come il numero TVD o il numero dell'azienda agricola, nonché i dati di base sull'identità e l'indirizzo di contatto della persona.
         Questi dati garantiscono che tutti i movimenti e gli eventi degli animali possano essere correttamente attribuiti a un detentore, essenziale per la tracciabilità e il rispetto dei requisiti legali.
         """@it ;
-    systemmap:containedIn systemmap:SYS020 ;
+    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ ;
     systemmap:informedBy systemmap:INF014 .
 
 systemmap:INF010 a systemmap:Information ;
@@ -2330,7 +2330,7 @@ systemmap:INF010 a systemmap:Information ;
         "Catalog of recognized agricultural plant varieties used in Switzerland. The information is recorded by breeders."@en,
         "Catalogue des variétés de plantes agricoles reconnues utilisées en Suisse. Les informations sont enregistrées par les sélectionneurs."@fr,
         "Catalogo delle varietà di piante agricole riconosciute utilizzate in Svizzera. Le informazioni sono registrate dai selezionatori."@it ;
-    systemmap:containedIn systemmap:SYS011 ;
+    systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj ;
     systemmap:informedBy systemmap:INF012 .
 
 systemmap:INF012 a systemmap:Information ;
@@ -2412,42 +2412,8 @@ systemmap:INF015 a systemmap:Information ;
         Copre quasi il 100% delle aziende e raccoglie variabili come le dimensioni aziendali, le superfici coltivate, il numero di animali da allevamento e gli occupati.
         L'indagine serve per l'analisi statistica dell'agricoltura, l'aggiornamento del registro delle aziende e le decisioni di politica agricola.
         """@it ;
-    systemmap:containedIn systemmap:SYS003 ;
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
     systemmap:informs systemmap:INF030 .
-
-systemmap:INF022 a systemmap:Information ;
-    rdfs:label "Daten zur Milchproduktion"@de,
-        "Data on milk production"@en,
-        "Données sur la production laitière"@fr,
-        "Dati sulla produzione di latte"@it ;
-    rdfs:comment """
-        Monatliche Produktionsmengen (in kg) der im Vormonat gelieferten Kuh- und Büffelmilch von allen Milchproduzenten.
-        Das BLW benötigt diese Information für die Ausrichtung der Zulage für Verkehrsmilch.
-        """@de,
-        """
-        Monthly production quantities (in kg) of cow and buffalo milk delivered in the previous month by all milk producers.
-        The BLW requires this information for the allocation of the subsidy for market milk.
-        """@en,
-        """
-        Quantités de production mensuelles (en kg) du lait de vache et de bufflonne livré le mois précédent par tous les producteurs de lait.
-        L'OFAG a besoin de ces informations pour l'octroi de la subvention pour le lait de consommation.
-        """@fr,
-        """
-        Quantità di produzione mensili (in kg) del latte di mucca e bufala consegnato nel mese precedente da tutti i produttori di latte.
-        L'UFAG necessita di queste informazioni per l'assegnazione del sussidio per il latte di consumo.
-        """@it ;
-    systemmap:containedIn systemmap:SYS021 .
-
-systemmap:INF023 a systemmap:Information ;
-    rdfs:label "Daten zur Milchverwertung"@de,
-        "Data on milk utilization"@en,
-        "Données sur la valorisation du lait"@fr,
-        "Dati sull'utilizzo del latte"@it ;
-    rdfs:comment "Diese Daten sind essenziell für die Berechnung und Auszahlung von Zulagen für verkäste Milch sowie für die Fütterung ohne Silage durch das Bundesamt für Landwirtschaft (BLW)."@de,
-        "These data are essential for the calculation and payment of subsidies for cheesed milk as well as for feeding without silage by the Federal Office for Agriculture (BLW)."@en,
-        "Ces données sont essentielles pour le calcul et le paiement des subventions pour le lait transformé en fromage ainsi que pour l'alimentation sans ensilage par l'Office fédéral de l'agriculture (OFAG)."@fr,
-        "Questi dati sono essenziali per il calcolo e il pagamento dei sussidi per il latte trasformato in formaggio e per l'alimentazione senza insilato da parte dell'Ufficio federale dell'agricoltura (UFAG)."@it ;
-    systemmap:containedIn systemmap:SYS021 .
 
 systemmap:INF025 a systemmap:Information ;
     rdfs:label "Daten zur Milchsegmentierung"@de,
@@ -2458,7 +2424,7 @@ systemmap:INF025 a systemmap:Information ;
         "Data on the segmentation of milk utilization according to the BOM1 regulation."@en,
         "Données sur la segmentation de la valorisation du lait selon le règlement BOM1."@fr,
         "Dati sulla segmentazione dell'utilizzo del latte secondo il regolamento BOM1."@it ;
-    systemmap:containedIn systemmap:SYS021 .
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
 systemmap:INF026 a systemmap:Information ;
     rdfs:label "Milchstatistik"@de,
@@ -2469,7 +2435,7 @@ systemmap:INF026 a systemmap:Information ;
         "Monthly statistics and multi-year comparisons containing information on the milk produced and its processing into different product groups."@en,
         "Statistiques mensuelles et comparaisons pluriannuelles contenant des informations sur le lait produit et sa transformation en différentes catégories de produits."@fr,
         "Statistiche mensili e confronti pluriennali contenenti informazioni sul latte prodotto e sulla sua trasformazione in diverse categorie di prodotti."@it ;
-    systemmap:containedIn systemmap:SYS021 .
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
 systemmap:INF028 a systemmap:Information ;
     rdfs:label "Details zu Unternehmen"@de,
@@ -2511,7 +2477,7 @@ systemmap:INF033 a systemmap:Information ;
         Raccolta di informazioni sui prodotti fitosanitari, i mangimi, i fertilizzanti minerali, i fertilizzanti agricoli e quelli riciclati.
         Ciò include gli identificatori, i nomi, le descrizioni, gli ingredienti e le quantità, ecc.
         """@it ;
-    systemmap:containedIn systemmap:SYS006 ;
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF ;
     systemmap:informedBy systemmap:INF037,
         systemmap:INF042 .
 
@@ -2532,7 +2498,7 @@ systemmap:INF034 a systemmap:Information ;
         """
         Lo spostamento dei fertilizzanti aziendali e riciclati include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
         """@it ;
-    systemmap:containedIn systemmap:SYS006 .
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
 
 systemmap:INF035 a systemmap:Information ;
     rdfs:label "Verschiebung von Mineraldüngern"@de,
@@ -2551,7 +2517,7 @@ systemmap:INF035 a systemmap:Information ;
         """
         Lo spostamento dei fertilizzanti minerali include la registrazione e la segnalazione di tutti gli afflussi e deflussi di fertilizzanti minerali, compresi acquisti, vendite e trasferimenti interni.
         """@it ;
-    systemmap:containedIn systemmap:SYS006 .
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
 
 systemmap:INF036 a systemmap:Information ;
     rdfs:label "Verschiebung von Pflanzenschutzmitteln"@de,
@@ -2570,7 +2536,7 @@ systemmap:INF036 a systemmap:Information ;
         """
         Lo spostamento dei prodotti fitosanitari include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
         """@it ;
-    systemmap:containedIn systemmap:SYS006 .
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
 
 systemmap:INF037 a systemmap:Information ;
     rdfs:label "Pflanzenschutzmittel"@de,
@@ -2589,7 +2555,7 @@ systemmap:INF037 a systemmap:Information ;
         """
         Elenco dei prodotti fitosanitari autorizzati in Svizzera, inclusa la loro composizione chimica, i numeri W e i titolari dell'autorizzazione.
         """@it ;
-    systemmap:containedIn systemmap:SYS017 .
+    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
 
 systemmap:INF038 a systemmap:Information ;
     rdfs:label "Kulturen und Schaderreger"@de,
@@ -2608,7 +2574,7 @@ systemmap:INF038 a systemmap:Information ;
         """
         Elenco delle colture e degli organismi nocivi per i quali è già stata concessa un'autorizzazione per un prodotto fitosanitario in Svizzera.
         """@it ;
-    systemmap:containedIn systemmap:SYS017 .
+    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
 
 systemmap:INF039 a systemmap:Information ;
     rdfs:label "Auflagen zur Anwendung von Pflanzenschutzmitteln"@de,
@@ -2627,7 +2593,7 @@ systemmap:INF039 a systemmap:Information ;
         """
         Regolamenti e restrizioni da osservare nell'uso dei prodotti fitosanitari, inclusi dosaggio, tempistica dell'applicazione e misure protettive.
         """@it ;
-    systemmap:containedIn systemmap:SYS017 .
+    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
 
 systemmap:INF040 a systemmap:Information ;
     rdfs:label "Zubereitungen"@de,
@@ -2703,8 +2669,42 @@ systemmap:INF046 a systemmap:Information ;
         "Linked Data"@en,
         "Linked Data"@fr,
         "Linked Data"@it ;
-    systemmap:containedIn systemmap:SYS018,
-        systemmap:SYS019 .
+    systemmap:containedIn systemmap:QHFSc6xgsHF70IlUd,
+        systemmap:QpLZd1ojPxF0CvH28 .
+
+systemmap:QLXw4VofhYbzXVNKC a systemmap:Information ;
+    rdfs:label "Daten zur Milchverwertung"@de,
+        "Data on milk utilization"@en,
+        "Données sur la valorisation du lait"@fr,
+        "Dati sull'utilizzo del latte"@it ;
+    rdfs:comment "Diese Daten sind essenziell für die Berechnung und Auszahlung von Zulagen für verkäste Milch sowie für die Fütterung ohne Silage durch das Bundesamt für Landwirtschaft (BLW)."@de,
+        "These data are essential for the calculation and payment of subsidies for cheesed milk as well as for feeding without silage by the Federal Office for Agriculture (BLW)."@en,
+        "Ces données sont essentielles pour le calcul et le paiement des subventions pour le lait transformé en fromage ainsi que pour l'alimentation sans ensilage par l'Office fédéral de l'agriculture (OFAG)."@fr,
+        "Questi dati sono essenziali per il calcolo e il pagamento dei sussidi per il latte trasformato in formaggio e per l'alimentazione senza insilato da parte dell'Ufficio federale dell'agricoltura (UFAG)."@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+
+systemmap:Qe6Nt3cqogxz2d10g a systemmap:Information ;
+    rdfs:label "Daten zur Milchproduktion"@de,
+        "Data on milk production"@en,
+        "Données sur la production laitière"@fr,
+        "Dati sulla produzione di latte"@it ;
+    rdfs:comment """
+        Monatliche Produktionsmengen (in kg) der im Vormonat gelieferten Kuh- und Büffelmilch von allen Milchproduzenten.
+        Das BLW benötigt diese Information für die Ausrichtung der Zulage für Verkehrsmilch.
+        """@de,
+        """
+        Monthly production quantities (in kg) of cow and buffalo milk delivered in the previous month by all milk producers.
+        The BLW requires this information for the allocation of the subsidy for market milk.
+        """@en,
+        """
+        Quantités de production mensuelles (en kg) du lait de vache et de bufflonne livré le mois précédent par tous les producteurs de lait.
+        L'OFAG a besoin de ces informations pour l'octroi de la subvention pour le lait de consommation.
+        """@fr,
+        """
+        Quantità di produzione mensili (in kg) del latte di mucca e bufala consegnato nel mese precedente da tutti i produttori di latte.
+        L'UFAG necessita di queste informazioni per l'assegnazione del sussidio per il latte di consumo.
+        """@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
 systemmap:INF001 a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Bewirtschaftenden"@de,
@@ -2715,18 +2715,18 @@ systemmap:INF001 a systemmap:PersonInformation ;
         "Information on the contact details of farm managers, such as email addresses or phone numbers."@en,
         "Informations sur les coordonnées des exploitants agricoles, telles que les adresses e-mail ou les numéros de téléphone."@fr,
         "Informazioni sui dati di contatto dei gestori agricoli, come indirizzi e-mail o numeri di telefono."@it ;
-    systemmap:containedIn systemmap:SYS003 .
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
 systemmap:INF002 a systemmap:PersonInformation ;
     rdfs:label "Informationen der Strukturdatenerhebung"@de,
         "Information from the structural data survey"@en,
         "Informations de l'enquête sur les données structurelles"@fr,
         "Informazioni dall'indagine sui dati strutturali"@it ;
-    systemmap:containedIn systemmap:SYS012,
-        systemmap:SYS013,
-        systemmap:SYS014,
-        systemmap:SYS015,
-        systemmap:SYS016 ;
+    systemmap:containedIn systemmap:QMjqlEoVCR9wpTyN1,
+        systemmap:QPWOFHR512FuAc25b,
+        systemmap:QZ9LRAuSt2EOvBpqY,
+        systemmap:QmWEQ8lVlDS9ZwPkY,
+        systemmap:QpR2aDraNmiUXz55J ;
     systemmap:informs systemmap:INF015 .
 
 systemmap:INF011 a systemmap:PersonInformation ;
@@ -2738,7 +2738,7 @@ systemmap:INF011 a systemmap:PersonInformation ;
         "Contact details of breeders who provide information about the varieties to ProVar."@en,
         "Coordonnées des sélectionneurs qui fournissent des informations sur les variétés à ProVar."@fr,
         "Dati di contatto dei selezionatori che forniscono informazioni sulle varietà a ProVar."@it ;
-    systemmap:containedIn systemmap:SYS011 .
+    systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj .
 
 systemmap:INF014 a systemmap:PersonInformation ;
     rdfs:label "Betriebsdaten (Person, Betrieb)"@de,
@@ -2749,7 +2749,7 @@ systemmap:INF014 a systemmap:PersonInformation ;
         "Contains basic information about agricultural businesses and related individuals. This includes identification data, organizational structures, and details about individuals involved in the business (e.g., farm managers, family members, and employees)."@en,
         "Contient des informations de base sur les exploitations agricoles et les personnes associées. Cela inclut les données d'identification, les structures organisationnelles et les détails sur les personnes impliquées dans l'exploitation (p. ex. gestionnaires de ferme, membres de la famille et employés)."@fr,
         "Contiene informazioni di base sulle aziende agricole e sulle persone ad esse associate. Ciò include dati identificativi, strutture organizzative e dettagli sulle persone coinvolte nell'azienda (ad es. gestori dell'azienda, familiari e dipendenti)."@it ;
-    systemmap:containedIn systemmap:SYS003 ;
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
     systemmap:informs systemmap:INF030 ;
     systemmap:usesIdentifier systemmap:INF003,
         systemmap:INF004 .
@@ -2775,7 +2775,7 @@ systemmap:INF016 a systemmap:PersonInformation ;
         Contiene dati sui contributi finanziari alle aziende agricole.
         Ciò include informazioni sugli importi dei contributi, le basi di calcolo, i criteri e le modalità di pagamento, nonché i processi amministrativi sottostanti.
         """@it ;
-    systemmap:containedIn systemmap:SYS003 .
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
 systemmap:INF018 a systemmap:PersonInformation ;
     rdfs:label "Anmeldungen für Direktzahlungsarten"@de,
@@ -2798,30 +2798,7 @@ systemmap:INF018 a systemmap:PersonInformation ;
         Copre il processo e i dati relativi alla registrazione per diversi tipi di pagamenti diretti.
         Include informazioni sulle procedure di iscrizione, le scadenze, i requisiti e i moduli utilizzati per la richiesta.
         """@it ;
-    systemmap:containedIn systemmap:SYS003 .
-
-systemmap:INF020 a systemmap:PersonInformation ;
-    rdfs:label "Kontaktdaten Milchproduzenten"@de,
-        "Contact details of milk producers"@en,
-        "Coordonnées des producteurs de lait"@fr,
-        "Dati di contatto dei produttori di latte"@it ;
-    rdfs:comment "Kontaktdaten der Milchproduzenten wie Adressen, TVD-Nummer, AGIS-Nummer des Betriebs, AGIS Nummer des Bewirtschaftenden und Zahlungsinformationen für die Ausbezahlung der Zulage für verkäste Milch und die Zulage für Fütterung ohne Silage. Wenn möglich, werden diese Kontaktdaten aus AGIS bezogen."@de,
-        "Contact details of milk producers, such as addresses, TVD number, AGIS number of the farm, AGIS number of the operator, and payment information for the subsidy for cheesed milk and the subsidy for feeding without silage. If possible, these contact details are obtained from AGIS."@en,
-        "Coordonnées des producteurs de lait, telles que les adresses, le numéro TVD, le numéro AGIS de l'exploitation, le numéro AGIS de l'exploitant et les informations de paiement pour la subvention pour le lait transformé en fromage et la subvention pour l'alimentation sans ensilage. Si possible, ces coordonnées sont obtenues auprès d'AGIS."@fr,
-        "Dati di contatto dei produttori di latte, come indirizzi, numero TVD, numero AGIS dell'azienda, numero AGIS del gestore e informazioni di pagamento per il sussidio per il latte trasformato in formaggio e il sussidio per l'alimentazione senza insilato. Se possibile, questi dati di contatto vengono ottenuti da AGIS."@it ;
-    systemmap:containedIn systemmap:SYS021 ;
-    systemmap:informedBy systemmap:INF001 .
-
-systemmap:INF021 a systemmap:PersonInformation ;
-    rdfs:label "Kontaktdaten Milchverarbeiter"@de,
-        "Contact details of milk processors"@en,
-        "Coordonnées des transformateurs de lait"@fr,
-        "Dati di contatto dei trasformatori di latte"@it ;
-    rdfs:comment "Kontaktdaten der Milchverarbeiter wie Adressen oder Identifikationsnummern."@de,
-        "Contact details of milk processors, such as addresses or identification numbers."@en,
-        "Coordonnées des transformateurs de lait, telles que les adresses ou les numéros d'identification."@fr,
-        "Dati di contatto dei trasformatori di latte, come indirizzi o numeri di identificazione."@it ;
-    systemmap:containedIn systemmap:SYS021 .
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
 systemmap:INF027 a systemmap:PersonInformation ;
     rdfs:label "Stammdaten und Identifikatoren"@de,
@@ -2892,7 +2869,7 @@ systemmap:INF032 a systemmap:PersonInformation ;
         """
         Informazioni sulla data di importazione, il prodotto, l'importatore e il destinatario di un prodotto fitosanitario (PPP).
         """@it ;
-    systemmap:containedIn systemmap:SYS007 ;
+    systemmap:containedIn systemmap:QywklUB91myTH0cvS ;
     systemmap:informedBy systemmap:INF031 .
 
 systemmap:INF043 a systemmap:PersonInformation ;
@@ -2900,73 +2877,32 @@ systemmap:INF043 a systemmap:PersonInformation ;
         "Data on inspections and inspection results"@en,
         "Données sur les contrôles et les résultats des contrôles"@fr,
         "Dati sui controlli e sui risultati dei controlli"@it ;
-    systemmap:containedIn systemmap:SYS001 .
+    systemmap:containedIn systemmap:Q9VcxLSoIIwQjoexY .
 
-systemmap:48aba87e20664cdf98243337e6c6b5c9 a systemmap:PrivateOrganization ;
-    rdfs:label "Agroline"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+systemmap:QoY82Q0qEk9k0s3w3 a systemmap:PersonInformation ;
+    rdfs:label "Kontaktdaten Milchproduzenten"@de,
+        "Contact details of milk producers"@en,
+        "Coordonnées des producteurs de lait"@fr,
+        "Dati di contatto dei produttori di latte"@it ;
+    rdfs:comment "Kontaktdaten der Milchproduzenten wie Adressen, TVD-Nummer, AGIS-Nummer des Betriebs, AGIS Nummer des Bewirtschaftenden und Zahlungsinformationen für die Ausbezahlung der Zulage für verkäste Milch und die Zulage für Fütterung ohne Silage. Wenn möglich, werden diese Kontaktdaten aus AGIS bezogen."@de,
+        "Contact details of milk producers, such as addresses, TVD number, AGIS number of the farm, AGIS number of the operator, and payment information for the subsidy for cheesed milk and the subsidy for feeding without silage. If possible, these contact details are obtained from AGIS."@en,
+        "Coordonnées des producteurs de lait, telles que les adresses, le numéro TVD, le numéro AGIS de l'exploitation, le numéro AGIS de l'exploitant et les informations de paiement pour la subvention pour le lait transformé en fromage et la subvention pour l'alimentation sans ensilage. Si possible, ces coordonnées sont obtenues auprès d'AGIS."@fr,
+        "Dati di contatto dei produttori di latte, come indirizzi, numero TVD, numero AGIS dell'azienda, numero AGIS del gestore e informazioni di pagamento per il sussidio per il latte trasformato in formaggio e il sussidio per l'alimentazione senza insilato. Se possibile, questi dati di contatto vengono ottenuti da AGIS."@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP ;
+    systemmap:informedBy systemmap:INF001 .
 
-systemmap:ORG100 a systemmap:PrivateOrganization ;
-    rdfs:label "TSM Treuhand GmbH"@de,
-        "TSM Treuhand LLC"@en,
-        "TSM Treuhand S. à r. l."@fr,
-        "TSM Fiduciaria S. a g. l."@it ;
-    rdfs:comment """
-        Die TSM Treuhand GmbH erfüllt unterschiedliche öffentlich- und privatrechtliche Aufträge in der Agrar- und Lebensmittelbranche.
-        TSM steht für Treuhand, Statistik und Management. Die Haupttätigkeit der TSM besteht in der Verwaltung der Datenbank dbmilch.ch.
-        Zudem werden weitere Aufträge im Bereich Treuhand, Fondsverwaltungen, Statistiken und Exportkontrollen durchgeführt.
-        Der Hauptauftraggeber der TSM ist das Bundesamt für Landwirtschaft (BLW).
-        """@de,
-        """
-        TSM Treuhand LLC carries out various public and private law mandates in the agricultural and food sector.
-        TSM stands for Trust, Statistics, and Management. The main activity of TSM is the management of the dbmilch.ch database.
-        In addition, further assignments in the areas of fiduciary services, fund management, statistics, and export controls are carried out.
-        The main client of TSM is the Federal Office for Agriculture (BLW).
-        """@en,
-        """
-        TSM Fiduciaire S. à r. l. remplit divers mandats de droit public et privé dans le secteur agricole et alimentaire.
-        TSM signifie Fiduciaire, Statistique et Management. L'activité principale de TSM est la gestion de la base de données dbmilch.ch.
-        En outre, d'autres missions sont effectuées dans les domaines de la fiducie, de la gestion de fonds, des statistiques et des contrôles à l'exportation.
-        Le principal client de TSM est l'Office fédéral de l'agriculture (OFAG).
-        """@fr,
-        """
-        TSM Treuhand GmbH svolge diversi mandati di diritto pubblico e privato nel settore agricolo e alimentare.
-        TSM sta per Fiduciario, Statistica e Management. L'attività principale di TSM è la gestione del database dbmilch.ch.
-        Inoltre, vengono svolti altri incarichi nei settori della fiduciaria, della gestione dei fondi, delle statistiche e dei controlli all'esportazione.
-        Il principale committente di TSM è l'Ufficio federale dell'agricoltura (UFAG).
-        """@it ;
-    owl:sameAs zefix:427931 .
+systemmap:Qutd0KIj3Rf8GlSwq a systemmap:PersonInformation ;
+    rdfs:label "Kontaktdaten Milchverarbeiter"@de,
+        "Contact details of milk processors"@en,
+        "Coordonnées des transformateurs de lait"@fr,
+        "Dati di contatto dei trasformatori di latte"@it ;
+    rdfs:comment "Kontaktdaten der Milchverarbeiter wie Adressen oder Identifikationsnummern."@de,
+        "Contact details of milk processors, such as addresses or identification numbers."@en,
+        "Coordonnées des transformateurs de lait, telles que les adresses ou les numéros d'identification."@fr,
+        "Dati di contatto dei trasformatori di latte, come indirizzi o numeri di identificazione."@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
-systemmap:ORG101 a systemmap:PrivateOrganization ;
-    rdfs:label "Identitas AG"@de,
-        "Identitas AG"@en,
-        "Identitas AG"@fr,
-        "Identitas AG"@it ;
-    rdfs:comment """
-        Die Identitas AG entwickelt und betreibt Informationssysteme für die Tierverkehrsdatenbank der Schweiz.
-        Sie stellt Lösungen für die Rückverfolgbarkeit von Tieren, Tiergesundheit und Lebensmittelsicherheit bereit.
-        Als IT-Dienstleister für Bund, Kantone und private Akteure bietet Identitas AG digitale Services zur Erfassung, Verarbeitung und Analyse von Tier- und Betriebsdaten an.
-        Das Unternehmen hat seinen Sitz in Bern.
-        """@de,
-        """
-        Identitas AG develops and operates information systems for Switzerland's animal traffic database.
-        It provides solutions for animal traceability, animal health, and food safety.
-        As an IT service provider for the federal government, cantons, and private actors, Identitas AG offers digital services for recording, processing, and analyzing animal and farm data.
-        The company is based in Bern."""@en,
-        """
-        Identitas AG développe et exploite des systèmes d'information pour la base de données du trafic des animaux en Suisse.
-        Elle propose des solutions pour la traçabilité des animaux, la santé animale et la sécurité alimentaire.
-        En tant que prestataire de services informatiques pour la Confédération, les cantons et les acteurs privés, Identitas AG fournit des services numériques pour la saisie, le traitement et l'analyse des données animales et agricoles.
-        L'entreprise est basée à Berne."""@fr,
-        """
-        Identitas AG sviluppa e gestisce sistemi informativi per la banca dati del traffico degli animali in Svizzera.
-        Fornisce soluzioni per la tracciabilità degli animali, la salute animale e la sicurezza alimentare.
-        In qualità di fornitore di servizi IT per la Confederazione, i cantoni e gli attori privati, Identitas AG offre servizi digitali per la registrazione, l'elaborazione e l'analisi dei dati sugli animali e sulle aziende agricole.
-        L'azienda ha sede a Berna.
-        """@it ;
-    owl:sameAs zefix:449781 .
-
-systemmap:ORG102 a systemmap:PrivateOrganization ;
+systemmap:QDetpcQhSMo4IAeAb a systemmap:PrivateOrganization ;
     rdfs:label "Barto AG"@de,
         "Barto AG"@en,
         "Barto AG"@fr,
@@ -2995,9 +2931,9 @@ systemmap:ORG102 a systemmap:PrivateOrganization ;
         La piattaforma integra varie funzioni agronomiche e amministrative e consente una gestione efficiente delle risorse.
         Barto AG collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
         """@it ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
-systemmap:dd44a374e6ab40f4b692ffefdae72165 a systemmap:PrivateOrganization ;
+systemmap:QFAcWHo27bji7sVts a systemmap:PrivateOrganization ;
     rdfs:label "Fenaco Genossenschaft"@de,
         "Fenaco Cooperative"@en,
         "Coopérative Fenaco"@fr,
@@ -3028,6 +2964,70 @@ systemmap:dd44a374e6ab40f4b692ffefdae72165 a systemmap:PrivateOrganization ;
         """@it ;
     owl:sameAs zefix:328631 .
 
+systemmap:QHObqf1JYpt7KGLFS a systemmap:PrivateOrganization ;
+    rdfs:label "Identitas AG"@de,
+        "Identitas AG"@en,
+        "Identitas AG"@fr,
+        "Identitas AG"@it ;
+    rdfs:comment """
+        Die Identitas AG entwickelt und betreibt Informationssysteme für die Tierverkehrsdatenbank der Schweiz.
+        Sie stellt Lösungen für die Rückverfolgbarkeit von Tieren, Tiergesundheit und Lebensmittelsicherheit bereit.
+        Als IT-Dienstleister für Bund, Kantone und private Akteure bietet Identitas AG digitale Services zur Erfassung, Verarbeitung und Analyse von Tier- und Betriebsdaten an.
+        Das Unternehmen hat seinen Sitz in Bern.
+        """@de,
+        """
+        Identitas AG develops and operates information systems for Switzerland's animal traffic database.
+        It provides solutions for animal traceability, animal health, and food safety.
+        As an IT service provider for the federal government, cantons, and private actors, Identitas AG offers digital services for recording, processing, and analyzing animal and farm data.
+        The company is based in Bern."""@en,
+        """
+        Identitas AG développe et exploite des systèmes d'information pour la base de données du trafic des animaux en Suisse.
+        Elle propose des solutions pour la traçabilité des animaux, la santé animale et la sécurité alimentaire.
+        En tant que prestataire de services informatiques pour la Confédération, les cantons et les acteurs privés, Identitas AG fournit des services numériques pour la saisie, le traitement et l'analyse des données animales et agricoles.
+        L'entreprise est basée à Berne."""@fr,
+        """
+        Identitas AG sviluppa e gestisce sistemi informativi per la banca dati del traffico degli animali in Svizzera.
+        Fornisce soluzioni per la tracciabilità degli animali, la salute animale e la sicurezza alimentare.
+        In qualità di fornitore di servizi IT per la Confederazione, i cantoni e gli attori privati, Identitas AG offre servizi digitali per la registrazione, l'elaborazione e l'analisi dei dati sugli animali e sulle aziende agricole.
+        L'azienda ha sede a Berna.
+        """@it ;
+    owl:sameAs zefix:449781 .
+
+systemmap:QQ3N7dTc23t2wzXr2 a systemmap:PrivateOrganization ;
+    rdfs:label "TSM Treuhand GmbH"@de,
+        "TSM Treuhand LLC"@en,
+        "TSM Treuhand S. à r. l."@fr,
+        "TSM Fiduciaria S. a g. l."@it ;
+    rdfs:comment """
+        Die TSM Treuhand GmbH erfüllt unterschiedliche öffentlich- und privatrechtliche Aufträge in der Agrar- und Lebensmittelbranche.
+        TSM steht für Treuhand, Statistik und Management. Die Haupttätigkeit der TSM besteht in der Verwaltung der Datenbank dbmilch.ch.
+        Zudem werden weitere Aufträge im Bereich Treuhand, Fondsverwaltungen, Statistiken und Exportkontrollen durchgeführt.
+        Der Hauptauftraggeber der TSM ist das Bundesamt für Landwirtschaft (BLW).
+        """@de,
+        """
+        TSM Treuhand LLC carries out various public and private law mandates in the agricultural and food sector.
+        TSM stands for Trust, Statistics, and Management. The main activity of TSM is the management of the dbmilch.ch database.
+        In addition, further assignments in the areas of fiduciary services, fund management, statistics, and export controls are carried out.
+        The main client of TSM is the Federal Office for Agriculture (BLW).
+        """@en,
+        """
+        TSM Fiduciaire S. à r. l. remplit divers mandats de droit public et privé dans le secteur agricole et alimentaire.
+        TSM signifie Fiduciaire, Statistique et Management. L'activité principale de TSM est la gestion de la base de données dbmilch.ch.
+        En outre, d'autres missions sont effectuées dans les domaines de la fiducie, de la gestion de fonds, des statistiques et des contrôles à l'exportation.
+        Le principal client de TSM est l'Office fédéral de l'agriculture (OFAG).
+        """@fr,
+        """
+        TSM Treuhand GmbH svolge diversi mandati di diritto pubblico e privato nel settore agricolo e alimentare.
+        TSM sta per Fiduciario, Statistica e Management. L'attività principale di TSM è la gestione del database dbmilch.ch.
+        Inoltre, vengono svolti altri incarichi nei settori della fiduciaria, della gestione dei fondi, delle statistiche e dei controlli all'esportazione.
+        Il principale committente di TSM è l'Ufficio federale dell'agricoltura (UFAG).
+        """@it ;
+    owl:sameAs zefix:427931 .
+
+systemmap:QWdllcNbPnjdcm7om a systemmap:PrivateOrganization ;
+    rdfs:label "Agroline"@de ;
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+
 zefix:1256441 a systemmap:PrivateOrganization ;
     rdfs:label "mooh Genossenschaft"@de .
 
@@ -3036,34 +3036,34 @@ zefix:2595 a systemmap:PrivateOrganization ;
 
 zefix:330180 a systemmap:PrivateOrganization ;
     rdfs:label "Bison Schweiz AG"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 zefix:371013 a systemmap:PrivateOrganization ;
     rdfs:label "Ernst Sutter AG"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 zefix:432768 a systemmap:PrivateOrganization ;
     rdfs:label "TRAVECO Transporte AG"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 zefix:446080 a systemmap:PrivateOrganization ;
     rdfs:label "frigemo ag"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 zefix:505628 a systemmap:PrivateOrganization ;
     rdfs:label "Isagri GmbH"@de .
 
 zefix:7011 a systemmap:PrivateOrganization ;
     rdfs:label "Anicom AG"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 zefix:76693 a systemmap:PrivateOrganization ;
     rdfs:label "Halag Chemie AG"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 zefix:787227 a systemmap:PrivateOrganization ;
     rdfs:label "RAMSEIER Suisse AG"@de ;
-    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
 systemmap:INF017 a systemmap:SensitivePersonInformation ;
     rdfs:label "Kürzungen von Direktzahlungen"@de,
@@ -3086,7 +3086,7 @@ systemmap:INF017 a systemmap:SensitivePersonInformation ;
         Contiene informazioni sulle normative e le procedure in base alle quali i pagamenti diretti alle aziende agricole vengono ridotti.  
         I dati includono criteri, basi di calcolo, periodi interessati e processi amministrativi che possono portare a tali riduzioni.  
         """@it ;
-    systemmap:containedIn systemmap:SYS003 .
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
 systemmap:INF024 a systemmap:SensitivePersonInformation ;
     rdfs:label "Resultate der Milchprüfung"@de,
@@ -3116,12 +3116,12 @@ systemmap:INF024 a systemmap:SensitivePersonInformation ;
         Risultati igienicamente insufficienti comportano reclami e, in caso di carenze igieniche prolungate, un divieto ufficiale di consegna del latte.
         I risultati del controllo del latte sono resi disponibili ai soggetti autorizzati tramite la piattaforma dbmilch.ch.
         """@it ;
-    systemmap:containedIn systemmap:SYS021 .
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
 systemmap:INF044 a systemmap:SensitivePersonInformation ;
     rdfs:label "Daten über Verwaltungsmassnahmen und strafrechtliche Sanktionen"@de,
         "Data on administrative measures and criminal sanctions"@en,
         "Données sur les mesures administratives et les sanctions pénales"@fr,
         "Dati sulle misure amministrative e sulle sanzioni penali"@it ;
-    systemmap:containedIn systemmap:SYS001 .
+    systemmap:containedIn systemmap:Q9VcxLSoIIwQjoexY .
 

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -88,7 +88,7 @@ LwG:art_27 a schema:Legislation ;
 <https://www.fedlex.admin.ch/eli/cc/2016/565> a schema:Legislation ;
     rdfs:label "Verordnung des BLW über die Festlegung von Perioden und Fristen sowie die Freigabe von Zollkontingentsteilmengen für die Einfuhr von frischem Gemüse und frischem Obst (VEAGOG-Freigabeverordnung)"@de .
 
-systemmap:Q6VSaFePQaMGqU8vD a schema:Organization ;
+systemmap:S6VSaFePQaMGqU8vD a schema:Organization ;
     rdfs:label "Schweizer Bundesarchiv"@de,
         "Swiss Federal Archives"@en,
         "Archives fédérales suisses"@fr,
@@ -107,7 +107,7 @@ systemmap:Q6VSaFePQaMGqU8vD a schema:Organization ;
         "AFS"@fr,
         "AFS"@it .
 
-systemmap:QBLH2G6TSKaqhqk4n a schema:Organization ;
+systemmap:SBLH2G6TSKaqhqk4n a schema:Organization ;
     rdfs:label "Internationale Union zum Schutz von Pflanzenzüchtungen"@de,
         "International Union for the Protection of New Varieties of Plants"@en,
         "Union internationale pour la protection des obtentions végétales"@fr,
@@ -130,14 +130,14 @@ systemmap:QBLH2G6TSKaqhqk4n a schema:Organization ;
         "UPOV"@fr,
         "UPOV"@it .
 
-systemmap:QGayLcAMcywbigd3M a schema:Organization ;
+systemmap:SGayLcAMcywbigd3M a schema:Organization ;
     rdfs:label "Gemeinsame Anmeldestelle Chemikalien"@de,
         "Common Notification Authority for Chemicals"@en,
         "Autorité commune de notification des produits chimiques"@fr,
         "Autorità comune di notifica delle sostanze chimiche"@it ;
-    schema:member systemmap:Q2QF8BOhJczC0PGhe,
-        systemmap:Q8WjMkerPw98ZkWA7,
-        systemmap:QwlgSr7ukziL6iHsP ;
+    schema:member systemmap:S2QF8BOhJczC0PGhe,
+        systemmap:S8WjMkerPw98ZkWA7,
+        systemmap:SwlgSr7ukziL6iHsP ;
     rdfs:comment """
         Die Gemeinsame Anmeldestelle Chemikalien ist die zentrale Anlaufstelle für Chemikalien in der Schweiz.
         Sie wird vom Bundesamt für Umwelt (BAFU), dem Bundesamt für Gesundheit (BAG) und dem Staatssekretariat für Wirtschaft (SECO) betrieben.
@@ -155,11 +155,11 @@ systemmap:QGayLcAMcywbigd3M a schema:Organization ;
         gestito dall'Ufficio federale dell'ambiente (UFAM), dall'Ufficio federale della sanità pubblica (UFSP) e dalla Segreteria di Stato dell'economia (SECO).
         """@it .
 
-systemmap:QhM5kJNFhO8vOAEdK a schema:Organization ;
+systemmap:ShM5kJNFhO8vOAEdK a schema:Organization ;
     rdfs:label "Europäische Kommission"@de,
         "European Commission"@en .
 
-systemmap:Q4gV9U3dvmENkSnj a schema:SoftwareApplication ;
+systemmap:S4gV9U3dvmENkSnj a schema:SoftwareApplication ;
     rdfs:label "Informationssystem für meldepflichtige Krankheiten"@de,
         "Information system for cases of notifiable diseases"@en,
         "Système d'information pour les maladies à déclaration obligatoire"@fr,
@@ -182,9 +182,9 @@ systemmap:Q4gV9U3dvmENkSnj a schema:SoftwareApplication ;
         "InfoSM"@en,
         "InfoSM"@fr,
         "InfoSM"@it ;
-    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
+    systemmap:operatedBy systemmap:SsFdxnjM8hgUdzVT5 .
 
-systemmap:Q6J4iyI6nMI2RCXSY a schema:SoftwareApplication ;
+systemmap:S6J4iyI6nMI2RCXSY a schema:SoftwareApplication ;
     rdfs:label "CePa"@de,
         "CePa"@en,
         "CePa"@fr,
@@ -193,9 +193,9 @@ systemmap:Q6J4iyI6nMI2RCXSY a schema:SoftwareApplication ;
         "CePa is an IT application for the digital management of procedures and correspondence within the framework of the plant passport system and the official certification of propagation material. It optimizes certification processes and ensures compliance with plant health regulations. In this way, it supports traceability and quality control of plant material."@en,
         "CePa est une application informatique pour la gestion numérique des procédures et de la correspondance dans le cadre du système de passeport phytosanitaire ainsi que de la certification officielle du matériel de multiplication. Elle optimise les processus de certification et garantit le respect des réglementations phytosanitaires. De cette manière, elle soutient la traçabilité et le contrôle de la qualité du matériel végétal."@fr,
         "CePa è un'applicazione IT per la gestione digitale delle procedure e della corrispondenza nell'ambito del sistema del passaporto delle piante e della certificazione ufficiale del materiale di propagazione. Ottimizza i processi di certificazione e garantisce il rispetto delle normative fitosanitarie. In questo modo, supporta la tracciabilità e il controllo della qualità del materiale vegetale."@it ;
-    systemmap:operatedBy systemmap:QFL2DYxeNnVaFsv64 .
+    systemmap:operatedBy systemmap:SFL2DYxeNnVaFsv64 .
 
-systemmap:Q7u1Bh6qfXUbSDkv a schema:SoftwareApplication ;
+systemmap:S7u1Bh6qfXUbSDkv a schema:SoftwareApplication ;
     rdfs:label "e-Deklaration"@de,
         "e-declaration"@en,
         "e-déclaration"@fr,
@@ -208,9 +208,9 @@ systemmap:Q7u1Bh6qfXUbSDkv a schema:SoftwareApplication ;
         "e-dec"@en,
         "e-dec"@fr,
         "e-dec"@it ;
-    systemmap:operatedBy systemmap:QFKPRpdGa5UISiJlx .
+    systemmap:operatedBy systemmap:SFKPRpdGa5UISiJlx .
 
-systemmap:Q9SbhGAwWjtvcRIZ a schema:SoftwareApplication ;
+systemmap:S9SbhGAwWjtvcRIZ a schema:SoftwareApplication ;
     rdfs:label "Geografisches Informationssystem"@de,
         "Geographic Information System"@en,
         "Système d'information géographique"@fr,
@@ -244,9 +244,9 @@ systemmap:Q9SbhGAwWjtvcRIZ a schema:SoftwareApplication ;
         "GIS-BLW"@fr,
         "GIS-BLW"@it ;
     systemmap:hasLegalBasis LwG:art_165_e ;
-    systemmap:operatedBy systemmap:QE8y4MuFWW5BKqK92 .
+    systemmap:operatedBy systemmap:SE8y4MuFWW5BKqK92 .
 
-systemmap:Q9VcxLSoIIwQjoexY a schema:SoftwareApplication ;
+systemmap:S9VcxLSoIIwQjoexY a schema:SoftwareApplication ;
     rdfs:label "Acontrol"@de,
         "Acontrol"@en,
         "Acontrol"@fr,
@@ -272,9 +272,9 @@ systemmap:Q9VcxLSoIIwQjoexY a schema:SoftwareApplication ;
         In questo modo, garantisce un monitoraggio efficiente e il rispetto degli standard agricoli.
         """@it ;
     systemmap:hasLegalBasis LwG:art_165_d ;
-    systemmap:operatedBy systemmap:QcoeXHl4TgJbke1Yf .
+    systemmap:operatedBy systemmap:ScoeXHl4TgJbke1Yf .
 
-systemmap:QBx5yiPz9Nxy2Wnue a schema:SoftwareApplication ;
+systemmap:SBx5yiPz9Nxy2Wnue a schema:SoftwareApplication ;
     rdfs:label "Mooh Intranet"@de ;
     rdfs:comment """
         Intranet-Seite der Mooh Genossenschaft.
@@ -282,7 +282,7 @@ systemmap:QBx5yiPz9Nxy2Wnue a schema:SoftwareApplication ;
     dcat:landingPage <https://intranet.mooh.swiss/> ;
     systemmap:operatedBy zefix:1256441 .
 
-systemmap:QE5DY78J7vgfoiDLj a schema:SoftwareApplication ;
+systemmap:SE5DY78J7vgfoiDLj a schema:SoftwareApplication ;
     rdfs:label "Protection Variété"@de,
         "Protection Variété"@en,
         "Protection Variété"@fr,
@@ -307,9 +307,9 @@ systemmap:QE5DY78J7vgfoiDLj a schema:SoftwareApplication ;
         "ProVar"@en,
         "ProVar"@fr,
         "ProVar"@it ;
-    systemmap:operatedBy systemmap:QfX7h09MplFWwb4LK .
+    systemmap:operatedBy systemmap:SfX7h09MplFWwb4LK .
 
-systemmap:QGdyOoksCnRRZwi2Q a schema:SoftwareApplication ;
+systemmap:SGdyOoksCnRRZwi2Q a schema:SoftwareApplication ;
     rdfs:label "Agate"@de,
         "Agate"@en,
         "Agate"@fr,
@@ -318,9 +318,9 @@ systemmap:QGdyOoksCnRRZwi2Q a schema:SoftwareApplication ;
         "Agate is an online portal that allows access to various agricultural applications with just one login. It facilitates data exchange in the agricultural and food sector, thereby increasing user convenience. This centralized access point simplifies administrative processes for all stakeholders."@en,
         "Agate est un portail en ligne qui permet d'accéder à diverses applications agricoles avec un seul identifiant. Il facilite l'échange de données dans le secteur agricole et alimentaire, augmentant ainsi le confort des utilisateurs. Ce point d'accès centralisé simplifie les processus administratifs pour toutes les parties prenantes."@fr,
         "Agate è un portale online che consente l'accesso a diverse applicazioni agricole con un solo login. Facilita lo scambio di dati nel settore agricolo e alimentare, aumentando così la comodità per gli utenti. Questo punto di accesso centralizzato semplifica i processi amministrativi per tutte le parti interessate."@it ;
-    systemmap:operatedBy systemmap:QQbNLiw8h9MnSXuyo .
+    systemmap:operatedBy systemmap:SQbNLiw8h9MnSXuyo .
 
-systemmap:QHEaRYIgvZ3xrDLo a schema:SoftwareApplication ;
+systemmap:SHEaRYIgvZ3xrDLo a schema:SoftwareApplication ;
     rdfs:label "Produkteregister Chemikalien"@de,
         "Chemical Products Register"@en,
         "Registre des produits chimiques"@fr,
@@ -347,9 +347,9 @@ systemmap:QHEaRYIgvZ3xrDLo a schema:SoftwareApplication ;
         "CPR"@en,
         "RPC"@fr,
         "RPC"@it ;
-    systemmap:operatedBy systemmap:QGayLcAMcywbigd3M .
+    systemmap:operatedBy systemmap:SGayLcAMcywbigd3M .
 
-systemmap:QHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
+systemmap:SHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
     rdfs:label "LINDAS"@de,
         "LINDAS"@en,
         "LINDAS"@fr,
@@ -358,9 +358,9 @@ systemmap:QHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
         "Linked Data Services LINDAS allow public administrations to publish their data in the form of Knowledge Graphs and make them accessible via https://lindas.admin.ch"@en,
         "Avec les services Linked Data LINDAS, les administrations publiques peuvent publier leurs données sous forme de graphe de connaissances et les rendre accessibles via https://lindas.admin.ch."@fr,
         "Con i Linked Data Services LINDAS, le pubbliche amministrazioni possono pubblicare i loro dati sotto forma di grafi di conoscenza e renderli accessibili attraverso https://lindas.admin.ch."@it ;
-    systemmap:operatedBy systemmap:Q6VSaFePQaMGqU8vD .
+    systemmap:operatedBy systemmap:S6VSaFePQaMGqU8vD .
 
-systemmap:QHyBeGX0LsQwjJ6Z a schema:SoftwareApplication ;
+systemmap:SHyBeGX0LsQwjJ6Z a schema:SoftwareApplication ;
     rdfs:label "Betriebs- und Unternehmensregister"@de,
         "Register of Enterprises and Establishments"@en,
         "Registre des entreprises et des établissements"@fr,
@@ -390,9 +390,9 @@ systemmap:QHyBeGX0LsQwjJ6Z a schema:SoftwareApplication ;
         "REE"@fr,
         "BUR"@it ;
     systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/1993/2253_2253_2253> ;
-    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
+    systemmap:operatedBy systemmap:SNbhMvt3Btta1U1d6 .
 
-systemmap:QLxeXHOfmC6DkBGl a schema:SoftwareApplication ;
+systemmap:SLxeXHOfmC6DkBGl a schema:SoftwareApplication ;
     rdfs:label "Zentrale Auswertung von Agrarumweltindikatoren"@de ;
     rdfs:comment """
         Die 'ZA-AUI: Betriebsrückmeldung' ermöglicht den Teilnehmenden am Projekt ZA-AUI die berechneten Agrarumweltindikatoren (AUI) ihres Betriebs online abzurufen, für welche sie jährlich Daten an Agroscope liefern.
@@ -404,7 +404,7 @@ systemmap:QLxeXHOfmC6DkBGl a schema:SoftwareApplication ;
     systemmap:abbreviation "ZA-AUI"@de ;
     systemmap:operatedBy staatskalender:20050530 .
 
-systemmap:QMjqlEoVCR9wpTyN1 a schema:SoftwareApplication ;
+systemmap:SMjqlEoVCR9wpTyN1 a schema:SoftwareApplication ;
     rdfs:label "Acorda"@de,
         "Acorda"@en,
         "Acorda"@fr,
@@ -429,12 +429,12 @@ systemmap:QMjqlEoVCR9wpTyN1 a schema:SoftwareApplication ;
         Il sistema offre funzionalità come la raccolta di dati strutturali, il calcolo e il pagamento dei sussidi diretti, la georeferenziazione e lo scambio di dati con i sistemi federali.
         Inoltre, include moduli specializzati per settori come l'apicoltura, la viticoltura e i controlli.
         """@it ;
-    systemmap:operatedBy systemmap:Q7eiByZp1HPEEO9Ty,
-        systemmap:QTBfdlLfF2K2AJypD,
-        systemmap:QTg0zUHrhEWXotIau,
-        systemmap:Qqo5ZJtzXw1gg3RYC .
+    systemmap:operatedBy systemmap:S7eiByZp1HPEEO9Ty,
+        systemmap:STBfdlLfF2K2AJypD,
+        systemmap:STg0zUHrhEWXotIau,
+        systemmap:Sqo5ZJtzXw1gg3RYC .
 
-systemmap:QNQSYR7J0IEZpyFT a schema:SoftwareApplication ;
+systemmap:SNQSYR7J0IEZpyFT a schema:SoftwareApplication ;
     rdfs:label "Auswertung/Analyse, Lebensmittelsicherheit, Veterinärwesen, Public Health"@de ;
     rdfs:comment """
         ALVPH ist das Datawarehouse des Veterinärdienstes Schweiz.
@@ -442,17 +442,17 @@ systemmap:QNQSYR7J0IEZpyFT a schema:SoftwareApplication ;
         Ausserdem verfügt ALVPH über viele graphische Funktionen, die eine attraktive Präsentation der Daten erlauben.
         """@de ;
     systemmap:abbreviation "ALVPH"@de ;
-    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
+    systemmap:operatedBy systemmap:SsFdxnjM8hgUdzVT5 .
 
-systemmap:QOL6kHAvPFNIuM9E a schema:SoftwareApplication ;
+systemmap:SOL6kHAvPFNIuM9E a schema:SoftwareApplication ;
     rdfs:label "Traces"@de ;
     rdfs:comment """
         Alle Personen und Firmen, die am Import- oder Exportprozess für den internationalen Handel von Tieren, Waren tierischen Ursprungs und gewissen Produkten nicht-tierischen Ursprungs beteiligt sind, müssen sich in Traces registrieren lassen.
         Es handelt sich um ein eine Webanwendung der Europäischen Union und unterstützt den grenzüberschreitenden Verkehr von Tieren, Lebensmitteln und tierischen Nebenprodukten.
         """@de ;
-    systemmap:operatedBy systemmap:QhM5kJNFhO8vOAEdK .
+    systemmap:operatedBy systemmap:ShM5kJNFhO8vOAEdK .
 
-systemmap:QPWOFHR512FuAc25b a schema:SoftwareApplication ;
+systemmap:SPWOFHR512FuAc25b a schema:SoftwareApplication ;
     rdfs:label "Gesamtlösung EDV Landwirtschaft & Natur"@de,
         "Comprehensive IT Solution for Agriculture & Nature"@en,
         "Solution informatique globale pour l'agriculture et la nature"@fr,
@@ -482,11 +482,11 @@ systemmap:QPWOFHR512FuAc25b a schema:SoftwareApplication ;
         "GELAN"@en,
         "GELAN"@fr,
         "GELAN"@it ;
-    systemmap:operatedBy systemmap:QnUxOsahtIQHfvRH9,
-        systemmap:Qp5pkmAETRpXrudck,
-        systemmap:QyTRdNaA9EH12lhiE .
+    systemmap:operatedBy systemmap:SnUxOsahtIQHfvRH9,
+        systemmap:Sp5pkmAETRpXrudck,
+        systemmap:SyTRdNaA9EH12lhiE .
 
-systemmap:QQfl1MHnNpsAj3WP a schema:SoftwareApplication ;
+systemmap:SQfl1MHnNpsAj3WP a schema:SoftwareApplication ;
     rdfs:label "DigiAgriFoodCH Systemlandkarte"@de,
         "DigiAgriFoodCH System Map"@en,
         "Carte du système DigiAgriFoodCH"@fr,
@@ -496,9 +496,9 @@ systemmap:QQfl1MHnNpsAj3WP a schema:SoftwareApplication ;
         "Un outil de visualisation des informations sur les systèmes informatiques, les données qu'ils contiennent et les organisations qui les exploitent dans le secteur agroalimentaire suisse."@fr,
         "Uno strumento di visualizzazione delle informazioni sui sistemi IT, i dati in essi contenuti e le organizzazioni che li gestiscono nel settore agroalimentare svizzero."@it ;
     dcat:landingPage <https://blw-ofag-ufag.github.io/system-map/> ;
-    systemmap:operatedBy systemmap:QFAwQAwxBcNnaURgO .
+    systemmap:operatedBy systemmap:SFAwQAwxBcNnaURgO .
 
-systemmap:QU88cJmqj8nBRl2KZ a schema:SoftwareApplication ;
+systemmap:SU88cJmqj8nBRl2KZ a schema:SoftwareApplication ;
     rdfs:label "Tierverkehrsdatenbank"@de,
         "Animal Traffic Database"@en,
         "Banque de données sur le trafic des animaux"@fr,
@@ -527,9 +527,9 @@ systemmap:QU88cJmqj8nBRl2KZ a schema:SoftwareApplication ;
         "TVD"@en,
         "BDTA"@fr,
         "BDTA"@it ;
-    systemmap:operatedBy systemmap:QHObqf1JYpt7KGLFS .
+    systemmap:operatedBy systemmap:SHObqf1JYpt7KGLFS .
 
-systemmap:QXcby9KwakDGhBdP a schema:SoftwareApplication ;
+systemmap:SXcby9KwakDGhBdP a schema:SoftwareApplication ;
     rdfs:label "ACmobile"@de,
         "ACmobile"@en,
         "ACmobile"@fr,
@@ -546,9 +546,9 @@ systemmap:QXcby9KwakDGhBdP a schema:SoftwareApplication ;
         """
         ACmobile è una soluzione mobile indipendente dalla piattaforma per la registrazione elettronica dei risultati delle ispezioni e delle misure.
         """@it ;
-    systemmap:operatedBy systemmap:QmI5VgF2mECWT74i2 .
+    systemmap:operatedBy systemmap:SmI5VgF2mECWT74i2 .
 
-systemmap:QYOd1TkacTh6cr0xP a schema:SoftwareApplication ;
+systemmap:SYOd1TkacTh6cr0xP a schema:SoftwareApplication ;
     rdfs:label "Datenbank Milch"@de,
         "Milk Database"@en,
         "Base de données lait"@fr,
@@ -577,9 +577,9 @@ systemmap:QYOd1TkacTh6cr0xP a schema:SoftwareApplication ;
         "dbmilch"@en,
         "dbmilch"@fr,
         "dbmilch"@it ;
-    systemmap:operatedBy systemmap:QQ3N7dTc23t2wzXr2 .
+    systemmap:operatedBy systemmap:SQ3N7dTc23t2wzXr2 .
 
-systemmap:QZ9LRAuSt2EOvBpqY a schema:SoftwareApplication ;
+systemmap:SZ9LRAuSt2EOvBpqY a schema:SoftwareApplication ;
     rdfs:label "AGRICOLA"@de,
         "AGRICOLA"@en,
         "AGRICOLA"@fr,
@@ -608,20 +608,20 @@ systemmap:QZ9LRAuSt2EOvBpqY a schema:SoftwareApplication ;
         Oltre ai pagamenti diretti, supporta anche settori come i miglioramenti strutturali, il diritto fondiario e degli affitti, nonché la protezione della natura.
         Più di 21.000 agricoltori e 1.000 dipendenti amministrativi utilizzano il sistema, che gestisce flussi finanziari di oltre 1 miliardo di franchi svizzeri all'anno.
         """@it ;
-    systemmap:operatedBy systemmap:QAz4vX5eiySS4vwuk,
-        systemmap:QDMGFgrGMHxc0eoLM,
-        systemmap:QDp3fNLQF81wWfMDp,
-        systemmap:QEoV4sz2peVmH5wY0,
-        systemmap:QJJVVNtVPxf8nt8VM,
-        systemmap:QNWHuNKVk7ijs7Cbc,
-        systemmap:QTqW9eQHHZNwyCH8i,
-        systemmap:QU0OUwGdItzXRya4Q,
-        systemmap:QU6T65pDC37fWWSHG,
-        systemmap:QUqub30lwOqlTtDN2,
-        systemmap:QVpDMEiTfIVQsNzT8,
-        systemmap:QoVAiCrMPYG2LJxsA .
+    systemmap:operatedBy systemmap:SAz4vX5eiySS4vwuk,
+        systemmap:SDMGFgrGMHxc0eoLM,
+        systemmap:SDp3fNLQF81wWfMDp,
+        systemmap:SEoV4sz2peVmH5wY0,
+        systemmap:SJJVVNtVPxf8nt8VM,
+        systemmap:SNWHuNKVk7ijs7Cbc,
+        systemmap:STqW9eQHHZNwyCH8i,
+        systemmap:SU0OUwGdItzXRya4Q,
+        systemmap:SU6T65pDC37fWWSHG,
+        systemmap:SUqub30lwOqlTtDN2,
+        systemmap:SVpDMEiTfIVQsNzT8,
+        systemmap:SoVAiCrMPYG2LJxsA .
 
-systemmap:Qc6kZqxTyS0gFGCY a schema:SoftwareApplication ;
+systemmap:Sc6kZqxTyS0gFGCY a schema:SoftwareApplication ;
     rdfs:label "Marktdaten Analyse- und Reporting-System"@de,
         "Market Data Analysis and Reporting System"@en,
         "Système d'analyse et de reporting des données de marché"@fr,
@@ -642,9 +642,9 @@ systemmap:Qc6kZqxTyS0gFGCY a schema:SoftwareApplication ;
         "MARS III"@en,
         "MARS III"@fr,
         "MARS III"@it ;
-    systemmap:operatedBy systemmap:QaVyVVsIDkiDMtQq4 .
+    systemmap:operatedBy systemmap:SaVyVVsIDkiDMtQq4 .
 
-systemmap:QeJ36zAhO3AJJix8t a schema:SoftwareApplication ;
+systemmap:SeJ36zAhO3AJJix8t a schema:SoftwareApplication ;
     rdfs:label "Nationale Informationssystem für die Pflanzengenetischen Ressourcen für Ernährung und Landwirtschaft"@de,
         "National Information System for Plant Genetic Resources for Food and Agriculture"@en,
         "Système national d'information sur les ressources phytogénétiques pour l'alimentation et l'agriculture"@fr,
@@ -657,9 +657,9 @@ systemmap:QeJ36zAhO3AJJix8t a schema:SoftwareApplication ;
         "NIS-PGRFA"@en,
         "SNIRPAA"@fr,
         "SIN-RGVA"@it ;
-    systemmap:operatedBy systemmap:QMnIieexlpOQHsGvN .
+    systemmap:operatedBy systemmap:SMnIieexlpOQHsGvN .
 
-systemmap:Qfv81BPRW0TSnKhGg a schema:SoftwareApplication ;
+systemmap:Sfv81BPRW0TSnKhGg a schema:SoftwareApplication ;
     rdfs:label "Troup'O Herdenmanager"@de ;
     rdfs:comment """
         Troup'O ist eine Herdenmanagement-Software für Milchvieh-, Mutterkuh- und Mastbetriebe, die eine zentrale Verwaltung von Zuchtdaten, eine übersichtliche Tierkartei und grafische Analysen bietet.
@@ -668,15 +668,15 @@ systemmap:Qfv81BPRW0TSnKhGg a schema:SoftwareApplication ;
         """@de ;
     systemmap:operatedBy zefix:505628 .
 
-systemmap:Qfwx1dZMcl5OXtzb a schema:SoftwareApplication ;
+systemmap:Sfwx1dZMcl5OXtzb a schema:SoftwareApplication ;
     rdfs:label "Apinella"@de ;
     rdfs:comment """
         Software insbesondere für die Früherkennungsprogramm des kleiner Beutenkäfer bei Bienen.
         """@de ;
     dcat:landingPage <https://www.apinella.ch/> ;
-    systemmap:operatedBy systemmap:Q3Rf79NI3Pm1rfOlN .
+    systemmap:operatedBy systemmap:S3Rf79NI3Pm1rfOlN .
 
-systemmap:QgjZ0efLbuCR2HvN a schema:SoftwareApplication ;
+systemmap:SgjZ0efLbuCR2HvN a schema:SoftwareApplication ;
     rdfs:label "Pflanzensorten-Datenbank"@de,
         "Plant Variety Database"@en,
         "Base de données des variétés de plantes"@fr,
@@ -689,9 +689,9 @@ systemmap:QgjZ0efLbuCR2HvN a schema:SoftwareApplication ;
         "PLUTO"@en,
         "PLUTO"@fr,
         "PLUTO"@it ;
-    systemmap:operatedBy systemmap:QBLH2G6TSKaqhqk4n .
+    systemmap:operatedBy systemmap:SBLH2G6TSKaqhqk4n .
 
-systemmap:QhZO092di7cBnOm7F a schema:SoftwareApplication ;
+systemmap:ShZO092di7cBnOm7F a schema:SoftwareApplication ;
     rdfs:label "Business-Intelligence-System"@de,
         "Business Intelligence System"@en,
         "Système de Business Intelligence"@fr,
@@ -704,9 +704,9 @@ systemmap:QhZO092di7cBnOm7F a schema:SoftwareApplication ;
         "ASTAT"@en,
         "ASTAT"@fr,
         "ASTAT"@it ;
-    systemmap:operatedBy systemmap:QieZtzwlMAxzFY1op .
+    systemmap:operatedBy systemmap:SieZtzwlMAxzFY1op .
 
-systemmap:Qhhoiq8azX3SHGL3W a schema:SoftwareApplication ;
+systemmap:Shhoiq8azX3SHGL3W a schema:SoftwareApplication ;
     rdfs:label "Pflanzenschutzmittelverzeichnis"@de,
         "Plant Protection Products Directory"@en,
         "Répertoire des produits phytosanitaires"@fr,
@@ -729,9 +729,9 @@ systemmap:Qhhoiq8azX3SHGL3W a schema:SoftwareApplication ;
         """@it ;
     dcat:landingPage <https://www.psm.admin.ch/> ;
     systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/2010/340> ;
-    systemmap:operatedBy systemmap:QoqmfoevPVgr3d0AA .
+    systemmap:operatedBy systemmap:SoqmfoevPVgr3d0AA .
 
-systemmap:QjCVTMrYaOTygNcqF a schema:SoftwareApplication ;
+systemmap:SjCVTMrYaOTygNcqF a schema:SoftwareApplication ;
     rdfs:label "digiFLUX"@de,
         "digiFLUX"@en,
         "digiFLUX"@fr,
@@ -758,9 +758,9 @@ systemmap:QjCVTMrYaOTygNcqF a schema:SoftwareApplication ;
         """@it ;
     systemmap:hasLegalBasis LwG:art_165_f,
         LwG:art_165_f_bis ;
-    systemmap:operatedBy systemmap:QyfZhzeyT1CqJU0BP .
+    systemmap:operatedBy systemmap:SyfZhzeyT1CqJU0BP .
 
-systemmap:QlTSOXsBC2LN7Qkp a schema:SoftwareApplication ;
+systemmap:SlTSOXsBC2LN7Qkp a schema:SoftwareApplication ;
     rdfs:label "Barto"@de,
         "Barto"@en,
         "Barto"@fr,
@@ -785,9 +785,9 @@ systemmap:QlTSOXsBC2LN7Qkp a schema:SoftwareApplication ;
         Integra diverse funzioni agronomiche e amministrative e offre agli agricoltori una soluzione centrale per la gestione della loro azienda.
         Barto è gestita da Barto AG e collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
         """@it ;
-    systemmap:operatedBy systemmap:QDetpcQhSMo4IAeAb .
+    systemmap:operatedBy systemmap:SDetpcQhSMo4IAeAb .
 
-systemmap:QlfheulBjlQDwuaIM a schema:SoftwareApplication ;
+systemmap:SlfheulBjlQDwuaIM a schema:SoftwareApplication ;
     rdfs:label "HODUFLU"@de,
         "HODUFLU"@en,
         "HODUFLU"@fr,
@@ -808,9 +808,9 @@ systemmap:QlfheulBjlQDwuaIM a schema:SoftwareApplication ;
         HODUFLU è un programma online per la gestione standardizzata degli spostamenti di fertilizzanti aziendali e riciclati in agricoltura.
         Su questa pagina troverete l'accesso all'applicazione e documenti utili come il manuale utente di HODUFLU.
         """@it ;
-    systemmap:operatedBy systemmap:QyfZhzeyT1CqJU0BP .
+    systemmap:operatedBy systemmap:SyfZhzeyT1CqJU0BP .
 
-systemmap:QmWEQ8lVlDS9ZwPkY a schema:SoftwareApplication ;
+systemmap:SmWEQ8lVlDS9ZwPkY a schema:SoftwareApplication ;
     rdfs:label "LAWIS"@de,
         "LAWIS"@en,
         "LAWIS"@fr,
@@ -843,14 +843,14 @@ systemmap:QmWEQ8lVlDS9ZwPkY a schema:SoftwareApplication ;
         Offre funzionalità GIS e soluzioni mobili per i controlli.
         Il sistema gestisce circa 26.000 aziende agricole e 180.000 particelle e dispone di moduli aggiuntivi per la viticoltura (passaporto dell'uva) e la silvicoltura (portale forestale).
         """@it ;
-    systemmap:operatedBy systemmap:Q3wI1gDSK1eZB4l36,
-        systemmap:Q4uUJh3cptyvoesgV,
-        systemmap:QI9jTsa43C0A052y9,
-        systemmap:QRtndZW3LnFXhrQUR,
-        systemmap:QXdYExDt1RcJOS7AY,
-        systemmap:QkaW2ahXWYw9ueeOp .
+    systemmap:operatedBy systemmap:S3wI1gDSK1eZB4l36,
+        systemmap:S4uUJh3cptyvoesgV,
+        systemmap:SI9jTsa43C0A052y9,
+        systemmap:SRtndZW3LnFXhrQUR,
+        systemmap:SXdYExDt1RcJOS7AY,
+        systemmap:SkaW2ahXWYw9ueeOp .
 
-systemmap:QnM0KdtMBmniYOY8f a schema:SoftwareApplication ;
+systemmap:SnM0KdtMBmniYOY8f a schema:SoftwareApplication ;
     rdfs:label "Meine Agrardatenfreigabe"@de,
         "My Agricultural Data Release"@en,
         "Ma libération des données agricoles"@fr,
@@ -879,9 +879,9 @@ systemmap:QnM0KdtMBmniYOY8f a schema:SoftwareApplication ;
         "MADR"@en,
         "MLDA"@fr,
         "MRDA"@it ;
-    systemmap:operatedBy systemmap:QFAwQAwxBcNnaURgO .
+    systemmap:operatedBy systemmap:SFAwQAwxBcNnaURgO .
 
-systemmap:QpLZd1ojPxF0CvH28 a schema:SoftwareApplication ;
+systemmap:SpLZd1ojPxF0CvH28 a schema:SoftwareApplication ;
     rdfs:label "Visualize"@de,
         "Visualize"@en,
         "Visualize"@fr,
@@ -890,9 +890,9 @@ systemmap:QpLZd1ojPxF0CvH28 a schema:SoftwareApplication ;
         "Create and embed visualizations from any dataset provided by the LINDAS Linked Data Service."@en,
         "Créez et intégrez des visualisations à partir des jeux de données du service LINDAS (Linked Data)."@fr,
         "Crea ed incorpora visualizzazioni partendo dai dataset forniti dal servizio LINDAS (Linked Data)."@it ;
-    systemmap:operatedBy systemmap:QwlgSr7ukziL6iHsP .
+    systemmap:operatedBy systemmap:SwlgSr7ukziL6iHsP .
 
-systemmap:QpR2aDraNmiUXz55J a schema:SoftwareApplication ;
+systemmap:SpR2aDraNmiUXz55J a schema:SoftwareApplication ;
     rdfs:label "SAP Wallis"@de,
         "SAP Valais"@en,
         "SAP Valais"@fr,
@@ -917,18 +917,18 @@ systemmap:QpR2aDraNmiUXz55J a schema:SoftwareApplication ;
         Un'interfaccia web (ePDir) consente agli utenti esterni di inserire i dati.
         Il sistema è utilizzato dalle aziende agricole, dalle amministrazioni comunali e dalle organizzazioni di controllo ed è impiegato per la gestione dei dati federali e cantonali, dei pagamenti diretti e delle statistiche.
         """@it ;
-    systemmap:operatedBy systemmap:QG5yBV3kE5E5NMM7j .
+    systemmap:operatedBy systemmap:SG5yBV3kE5E5NMM7j .
 
-systemmap:QtGKp6nS3OwEm4I0 a schema:SoftwareApplication ;
+systemmap:StGKp6nS3OwEm4I0 a schema:SoftwareApplication ;
     rdfs:label "eMapis"@de ;
     rdfs:comment """
         eMapis wurde entwickelt, um die veraltete MAPIS-Applikation abzulösen und die digitale Verwaltung von Finanzhilfegesuchen, wie Bundesbeiträge und zinslose Darlehen, zu ermöglichen.
         Das System zentralisiert die Erfassung und Verwaltung von Daten sowie Dokumenten, wodurch Doppelerfassungen vermieden werden.
         Mit automatisierten Workflows, einer zentralen Benutzerverwaltung und der Integration von GIS-Daten (sowie zukünftig Betriebsdaten) verbessert eMapis die Transparenz und Effizienz in der Bearbeitung der Finanzhilfefälle.
         """@de ;
-    systemmap:operatedBy systemmap:QG8fSveeGZNcYzoUN .
+    systemmap:operatedBy systemmap:SG8fSveeGZNcYzoUN .
 
-systemmap:QuEtT7joC8HXVSfF a schema:SoftwareApplication ;
+systemmap:SuEtT7joC8HXVSfF a schema:SoftwareApplication ;
     rdfs:label "UID-Register"@de,
         "UID Register"@en,
         "Registre UID"@fr,
@@ -955,9 +955,9 @@ systemmap:QuEtT7joC8HXVSfF a schema:SoftwareApplication ;
         """@it ;
     rdfs:seeAlso <https://www.ech.ch/ech/ech-0108>,
         <https://www.uid.admin.ch/> ;
-    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
+    systemmap:operatedBy systemmap:SNbhMvt3Btta1U1d6 .
 
-systemmap:QvDlxaJ5YMkuZGH6k a schema:SoftwareApplication ;
+systemmap:SvDlxaJ5YMkuZGH6k a schema:SoftwareApplication ;
     rdfs:label "Agrarpolitisches Informationssystem"@de,
         "Agricultural Policy Information System"@en,
         "Système d'information sur la politique agricole"@fr,
@@ -971,9 +971,9 @@ systemmap:QvDlxaJ5YMkuZGH6k a schema:SoftwareApplication ;
         "SIPA"@fr,
         "AGIS"@it ;
     systemmap:hasLegalBasis LwG:art_165_c ;
-    systemmap:operatedBy systemmap:QE8y4MuFWW5BKqK92 .
+    systemmap:operatedBy systemmap:SE8y4MuFWW5BKqK92 .
 
-systemmap:QywklUB91myTH0cvS a schema:SoftwareApplication ;
+systemmap:SywklUB91myTH0cvS a schema:SoftwareApplication ;
     rdfs:label "eKontingente"@de,
         "eQuotas"@en,
         "eContingents"@fr,
@@ -998,13 +998,13 @@ systemmap:QywklUB91myTH0cvS a schema:SoftwareApplication ;
         <https://www.fedlex.admin.ch/eli/cc/2003/791>,
         <https://www.fedlex.admin.ch/eli/cc/2011/770>,
         <https://www.fedlex.admin.ch/eli/cc/2016/565> ;
-    systemmap:operatedBy systemmap:QRu4rav1Rlm2mUMWr .
+    systemmap:operatedBy systemmap:SRu4rav1Rlm2mUMWr .
 
-systemmap:Q1KtKkrBMoK25AKVA a systemmap:CantonalOrganization ;
+systemmap:S1KtKkrBMoK25AKVA a systemmap:CantonalOrganization ;
     rdfs:label "Direktzahlungen und Beiträge"@de ;
-    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+    schema:parentOrganization systemmap:SDMGFgrGMHxc0eoLM .
 
-systemmap:Q3wI1gDSK1eZB4l36 a systemmap:CantonalOrganization ;
+systemmap:S3wI1gDSK1eZB4l36 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Thurgau"@de,
         "Canton of Thurgau"@en,
         "Canton de Thurgovie"@fr,
@@ -1015,16 +1015,16 @@ systemmap:Q3wI1gDSK1eZB4l36 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Turgovia."@it ;
     systemmap:abbreviation "TG" .
 
-systemmap:Q4uUJh3cptyvoesgV a systemmap:CantonalOrganization ;
+systemmap:S4uUJh3cptyvoesgV a systemmap:CantonalOrganization ;
     rdfs:label "Landwirtschaft"@de ;
-    schema:parentOrganization systemmap:QtD442ueFttFeM59d .
+    schema:parentOrganization systemmap:StD442ueFttFeM59d .
 
-systemmap:Q5PQMffJ6VPs6c4Eg a systemmap:CantonalOrganization ;
+systemmap:S5PQMffJ6VPs6c4Eg a systemmap:CantonalOrganization ;
     rdfs:label "Land- und Forstwirtschaftsdepartement"@de ;
-    schema:parentOrganization systemmap:QP3XCaL5d9GyKtg5H ;
+    schema:parentOrganization systemmap:SP3XCaL5d9GyKtg5H ;
     systemmap:abbreviation "LFD"@de .
 
-systemmap:Q7eiByZp1HPEEO9Ty a systemmap:CantonalOrganization ;
+systemmap:S7eiByZp1HPEEO9Ty a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Waadt"@de,
         "Canton of Vaud"@en,
         "Canton de Vaud"@fr,
@@ -1035,7 +1035,7 @@ systemmap:Q7eiByZp1HPEEO9Ty a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Vaud."@it ;
     systemmap:abbreviation "VD" .
 
-systemmap:QAz4vX5eiySS4vwuk a systemmap:CantonalOrganization ;
+systemmap:SAz4vX5eiySS4vwuk a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Obwalden"@de,
         "Canton of Obwalden"@en,
         "Canton d'Obwald"@fr,
@@ -1046,7 +1046,7 @@ systemmap:QAz4vX5eiySS4vwuk a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Obvaldo."@it ;
     systemmap:abbreviation "OW" .
 
-systemmap:QCC189KCYnABsbian a systemmap:CantonalOrganization ;
+systemmap:SCC189KCYnABsbian a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Appenzell Ausserrhoden"@de,
         "Canton of Appenzell Ausserrhoden"@en,
         "Canton d'Appenzell Rhodes-Extérieures"@fr,
@@ -1057,11 +1057,11 @@ systemmap:QCC189KCYnABsbian a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Appenzell Esterno."@it ;
     systemmap:abbreviation "AR" .
 
-systemmap:QDMGFgrGMHxc0eoLM a systemmap:CantonalOrganization ;
+systemmap:SDMGFgrGMHxc0eoLM a systemmap:CantonalOrganization ;
     rdfs:label "Landwirtschaft Aargau"@de ;
-    schema:parentOrganization systemmap:QXgifgY4eK6N4W9jr .
+    schema:parentOrganization systemmap:SXgifgY4eK6N4W9jr .
 
-systemmap:QDp3fNLQF81wWfMDp a systemmap:CantonalOrganization ;
+systemmap:SDp3fNLQF81wWfMDp a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Tessin"@de,
         "Canton of Ticino"@en,
         "Canton du Tessin"@fr,
@@ -1072,7 +1072,7 @@ systemmap:QDp3fNLQF81wWfMDp a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Ticino."@it ;
     systemmap:abbreviation "TI" .
 
-systemmap:QEoV4sz2peVmH5wY0 a systemmap:CantonalOrganization ;
+systemmap:SEoV4sz2peVmH5wY0 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Schwyz"@de,
         "Canton of Schwyz"@en,
         "Canton de Schwytz"@fr,
@@ -1083,7 +1083,7 @@ systemmap:QEoV4sz2peVmH5wY0 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Svitto."@it ;
     systemmap:abbreviation "SZ" .
 
-systemmap:QG5yBV3kE5E5NMM7j a systemmap:CantonalOrganization ;
+systemmap:SG5yBV3kE5E5NMM7j a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Wallis"@de,
         "Canton of Valais"@en,
         "Canton du Valais"@fr,
@@ -1094,7 +1094,7 @@ systemmap:QG5yBV3kE5E5NMM7j a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale del Vallese."@it ;
     systemmap:abbreviation "VS" .
 
-systemmap:QGkAVZIrJPw0HqHLs a systemmap:CantonalOrganization ;
+systemmap:SGkAVZIrJPw0HqHLs a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Aargau"@de,
         "Canton of Aargau"@en,
         "Canton d'Argovie"@fr,
@@ -1105,7 +1105,7 @@ systemmap:QGkAVZIrJPw0HqHLs a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Argovia."@it ;
     systemmap:abbreviation "AG" .
 
-systemmap:QI9jTsa43C0A052y9 a systemmap:CantonalOrganization ;
+systemmap:SI9jTsa43C0A052y9 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Schaffhausen"@de,
         "Canton of Schaffhausen"@en,
         "Canton de Schaffhouse"@fr,
@@ -1116,7 +1116,7 @@ systemmap:QI9jTsa43C0A052y9 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Schaffhausen."@it ;
     systemmap:abbreviation "SH" .
 
-systemmap:QJJVVNtVPxf8nt8VM a systemmap:CantonalOrganization ;
+systemmap:SJJVVNtVPxf8nt8VM a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Uri"@de,
         "Canton of Uri"@en,
         "Canton d'Uri"@fr,
@@ -1127,20 +1127,20 @@ systemmap:QJJVVNtVPxf8nt8VM a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Uri."@it ;
     systemmap:abbreviation "UR" .
 
-systemmap:QKUAYpzZ9E3EItXRv a systemmap:CantonalOrganization ;
+systemmap:SKUAYpzZ9E3EItXRv a systemmap:CantonalOrganization ;
     rdfs:label "Koordinationsstelle für das Adress- und Betriebsregister"@de ;
-    schema:parentOrganization systemmap:QSTWtmHeK8GuPkomQ .
+    schema:parentOrganization systemmap:SSTWtmHeK8GuPkomQ .
 
-systemmap:QNR9jjxZTYmU0qC1N a systemmap:CantonalOrganization ;
+systemmap:SNR9jjxZTYmU0qC1N a systemmap:CantonalOrganization ;
     rdfs:label "Amt für Landwirtschaft"@de ;
-    schema:parentOrganization systemmap:QX3LDErwHN1dlwmGS ;
+    schema:parentOrganization systemmap:SX3LDErwHN1dlwmGS ;
     rdfs:comment """
         Das Amt für Landwirtschaft des Kantons Appenzell Ausserrhoden unterstützt die landwirtschaftlichen Betriebe in der Region durch Beratung, Fördermassnahmen und administrative Dienstleistungen.
         Es setzt sich für eine nachhaltige und wirtschaftlich tragfähige Landwirtschaft ein und ist für die Umsetzung agrarpolitischer Vorgaben zuständig.
         Zudem betreut es Bereiche wie Direktzahlungen, Strukturverbesserungen und Ausbildung in der Landwirtschaft.
         """@de .
 
-systemmap:QNWHuNKVk7ijs7Cbc a systemmap:CantonalOrganization ;
+systemmap:SNWHuNKVk7ijs7Cbc a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Graubünden"@de,
         "Canton of Graubünden"@en,
         "Canton des Grisons"@fr,
@@ -1151,7 +1151,7 @@ systemmap:QNWHuNKVk7ijs7Cbc a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale dei Grigioni."@it ;
     systemmap:abbreviation "GR" .
 
-systemmap:QP3XCaL5d9GyKtg5H a systemmap:CantonalOrganization ;
+systemmap:SP3XCaL5d9GyKtg5H a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Appenzell Innerrhoden"@de,
         "Canton of Appenzell Innerrhoden"@en,
         "Canton d'Appenzell Rhodes-Intérieures"@fr,
@@ -1162,7 +1162,7 @@ systemmap:QP3XCaL5d9GyKtg5H a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Appenzell Interno."@it ;
     systemmap:abbreviation "AI" .
 
-systemmap:QRtndZW3LnFXhrQUR a systemmap:CantonalOrganization ;
+systemmap:SRtndZW3LnFXhrQUR a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Zug"@de,
         "Canton of Zug"@en,
         "Canton de Zoug"@fr,
@@ -1173,11 +1173,11 @@ systemmap:QRtndZW3LnFXhrQUR a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Zugo."@it ;
     systemmap:abbreviation "ZG" .
 
-systemmap:QSTWtmHeK8GuPkomQ a systemmap:CantonalOrganization ;
+systemmap:SSTWtmHeK8GuPkomQ a systemmap:CantonalOrganization ;
     rdfs:label "Abteilung Direktzahlungen"@de ;
-    schema:parentOrganization systemmap:QnUxOsahtIQHfvRH9 .
+    schema:parentOrganization systemmap:SnUxOsahtIQHfvRH9 .
 
-systemmap:QTBfdlLfF2K2AJypD a systemmap:CantonalOrganization ;
+systemmap:STBfdlLfF2K2AJypD a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Jura"@de,
         "Canton of Jura"@en,
         "Canton du Jura"@fr,
@@ -1188,7 +1188,7 @@ systemmap:QTBfdlLfF2K2AJypD a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale del Giura."@it ;
     systemmap:abbreviation "JU" .
 
-systemmap:QTg0zUHrhEWXotIau a systemmap:CantonalOrganization ;
+systemmap:STg0zUHrhEWXotIau a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Neuenburg"@de,
         "Canton of Neuchâtel"@en,
         "Canton de Neuchâtel"@fr,
@@ -1199,7 +1199,7 @@ systemmap:QTg0zUHrhEWXotIau a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Neuchâtel."@it ;
     systemmap:abbreviation "NE" .
 
-systemmap:QTqW9eQHHZNwyCH8i a systemmap:CantonalOrganization ;
+systemmap:STqW9eQHHZNwyCH8i a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Zürich"@de,
         "Canton of Zurich"@en,
         "Canton de Zurich"@fr,
@@ -1210,7 +1210,7 @@ systemmap:QTqW9eQHHZNwyCH8i a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Zurigo."@it ;
     systemmap:abbreviation "ZH" .
 
-systemmap:QU0OUwGdItzXRya4Q a systemmap:CantonalOrganization ;
+systemmap:SU0OUwGdItzXRya4Q a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Nidwalden"@de,
         "Canton of Nidwalden"@en,
         "Canton de Nidwald"@fr,
@@ -1221,11 +1221,11 @@ systemmap:QU0OUwGdItzXRya4Q a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Nidvaldo."@it ;
     systemmap:abbreviation "NW" .
 
-systemmap:QU6T65pDC37fWWSHG a systemmap:CantonalOrganization ;
+systemmap:SU6T65pDC37fWWSHG a systemmap:CantonalOrganization ;
     rdfs:label "Landwirtschaftsamt"@de ;
-    schema:parentOrganization systemmap:Q5PQMffJ6VPs6c4Eg .
+    schema:parentOrganization systemmap:S5PQMffJ6VPs6c4Eg .
 
-systemmap:QUqub30lwOqlTtDN2 a systemmap:CantonalOrganization ;
+systemmap:SUqub30lwOqlTtDN2 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton St. Gallen"@de,
         "Canton of St. Gallen"@en,
         "Canton de Saint-Gall"@fr,
@@ -1236,19 +1236,19 @@ systemmap:QUqub30lwOqlTtDN2 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di San Gallo."@it ;
     systemmap:abbreviation "SG" .
 
-systemmap:QVpDMEiTfIVQsNzT8 a systemmap:CantonalOrganization ;
+systemmap:SVpDMEiTfIVQsNzT8 a systemmap:CantonalOrganization ;
     rdfs:label "Direktzahlungen und Tierzucht"@de ;
-    schema:parentOrganization systemmap:QNR9jjxZTYmU0qC1N .
+    schema:parentOrganization systemmap:SNR9jjxZTYmU0qC1N .
 
-systemmap:QVziLYQkMiRWMaajH a systemmap:CantonalOrganization ;
+systemmap:SVziLYQkMiRWMaajH a systemmap:CantonalOrganization ;
     rdfs:label "Zentrale Dienste"@de ;
-    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+    schema:parentOrganization systemmap:SDMGFgrGMHxc0eoLM .
 
-systemmap:QX3LDErwHN1dlwmGS a systemmap:CantonalOrganization ;
+systemmap:SX3LDErwHN1dlwmGS a systemmap:CantonalOrganization ;
     rdfs:label "Departement Bau und Volkswirtschaft"@de ;
-    schema:parentOrganization systemmap:QCC189KCYnABsbian .
+    schema:parentOrganization systemmap:SCC189KCYnABsbian .
 
-systemmap:QXdYExDt1RcJOS7AY a systemmap:CantonalOrganization ;
+systemmap:SXdYExDt1RcJOS7AY a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Luzern"@de,
         "Canton of Lucerne"@en,
         "Canton de Lucerne"@fr,
@@ -1259,11 +1259,11 @@ systemmap:QXdYExDt1RcJOS7AY a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Lucerna."@it ;
     systemmap:abbreviation "LU" .
 
-systemmap:QXgifgY4eK6N4W9jr a systemmap:CantonalOrganization ;
+systemmap:SXgifgY4eK6N4W9jr a systemmap:CantonalOrganization ;
     rdfs:label "Departement Finanzen und Ressourcen"@de ;
-    schema:parentOrganization systemmap:QGkAVZIrJPw0HqHLs .
+    schema:parentOrganization systemmap:SGkAVZIrJPw0HqHLs .
 
-systemmap:QfCWpkO67ty1HLzmK a systemmap:CantonalOrganization ;
+systemmap:SfCWpkO67ty1HLzmK a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Basel-Stadt"@de,
         "Canton of Basel-Stadt"@en,
         "Canton de Bâle-Ville"@fr,
@@ -1274,20 +1274,20 @@ systemmap:QfCWpkO67ty1HLzmK a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Basilea Città."@it ;
     systemmap:abbreviation "BS" .
 
-systemmap:QjozrVSzUVos5diiL a systemmap:CantonalOrganization ;
+systemmap:SjozrVSzUVos5diiL a systemmap:CantonalOrganization ;
     rdfs:label "Landwirtschaftliches Zentrum Liebegg"@de ;
-    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+    schema:parentOrganization systemmap:SDMGFgrGMHxc0eoLM .
 
-systemmap:QkaW2ahXWYw9ueeOp a systemmap:CantonalOrganization ;
+systemmap:SkaW2ahXWYw9ueeOp a systemmap:CantonalOrganization ;
     rdfs:label "Ebenrain-Zentrum für Landwirtschaft, Natur und Ernährung"@de ;
-    schema:parentOrganization systemmap:QzHOtHCVjJXECjyDj ;
+    schema:parentOrganization systemmap:SzHOtHCVjJXECjyDj ;
     rdfs:comment "Das Ebenrain-Zentrum für Landwirtschaft, Natur und Ernährung mit Sitz in Sissach übernimmt die Aufgaben des Kantons zugunsten von Landwirtschaft, Natur und Ernährung. Der Ebenrain führt eine landwirtschaftliche Schule zur Ausbildung der Landwirte und Landwirtinnen, die Brücke Ebenrain sowie einen Kursgarten für die praktische Bildungsarbeit. Mit Kursen und Beratung sorgt er dafür, dass die Landwirtinnen und Landwirte fachlich fit für die Zukunft sind. Er fördert eine gesunde und ausgewogene Ernährung in der Gemeinschaftsgastronomie und in der breiten Bevölkerung."@de .
 
-systemmap:Qlsq3Et7cyDrThfMW a systemmap:CantonalOrganization ;
+systemmap:Slsq3Et7cyDrThfMW a systemmap:CantonalOrganization ;
     rdfs:label "Departement Gesundheit und Soziales"@de ;
-    schema:parentOrganization systemmap:QGkAVZIrJPw0HqHLs .
+    schema:parentOrganization systemmap:SGkAVZIrJPw0HqHLs .
 
-systemmap:QmI5VgF2mECWT74i2 a systemmap:CantonalOrganization ;
+systemmap:SmI5VgF2mECWT74i2 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Bern"@de,
         "Canton of Bern"@en,
         "Canton de Berne"@fr,
@@ -1298,12 +1298,12 @@ systemmap:QmI5VgF2mECWT74i2 a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Berna."@it ;
     systemmap:abbreviation "BE" .
 
-systemmap:QnUxOsahtIQHfvRH9 a systemmap:CantonalOrganization ;
+systemmap:SnUxOsahtIQHfvRH9 a systemmap:CantonalOrganization ;
     rdfs:label "Amt für Landwirtschaft und Natur"@de ;
-    schema:parentOrganization systemmap:QmI5VgF2mECWT74i2 ;
+    schema:parentOrganization systemmap:SmI5VgF2mECWT74i2 ;
     systemmap:abbreviation "LANAT"@de .
 
-systemmap:QoVAiCrMPYG2LJxsA a systemmap:CantonalOrganization ;
+systemmap:SoVAiCrMPYG2LJxsA a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Glarus"@de,
         "Canton of Glarus"@en,
         "Canton de Glaris"@fr,
@@ -1314,7 +1314,7 @@ systemmap:QoVAiCrMPYG2LJxsA a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Glarus."@it ;
     systemmap:abbreviation "GL" .
 
-systemmap:Qp5pkmAETRpXrudck a systemmap:CantonalOrganization ;
+systemmap:Sp5pkmAETRpXrudck a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Freiburg"@de,
         "Canton of Fribourg"@en,
         "Canton de Fribourg"@fr,
@@ -1325,11 +1325,11 @@ systemmap:Qp5pkmAETRpXrudck a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Friburgo."@it ;
     systemmap:abbreviation "FR" .
 
-systemmap:QpJ9AAjLlCAkFBhVU a systemmap:CantonalOrganization ;
+systemmap:SpJ9AAjLlCAkFBhVU a systemmap:CantonalOrganization ;
     rdfs:label "Strategie und Planung"@de ;
-    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+    schema:parentOrganization systemmap:SDMGFgrGMHxc0eoLM .
 
-systemmap:Qqo5ZJtzXw1gg3RYC a systemmap:CantonalOrganization ;
+systemmap:Sqo5ZJtzXw1gg3RYC a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Genf"@de,
         "Canton of Geneva"@en,
         "Canton de Genève"@fr,
@@ -1340,15 +1340,15 @@ systemmap:Qqo5ZJtzXw1gg3RYC a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Ginevra."@it ;
     systemmap:abbreviation "GE" .
 
-systemmap:QtD442ueFttFeM59d a systemmap:CantonalOrganization ;
+systemmap:StD442ueFttFeM59d a systemmap:CantonalOrganization ;
     rdfs:label "Amt für Umwelt und Energie"@de ;
-    schema:parentOrganization systemmap:QfCWpkO67ty1HLzmK .
+    schema:parentOrganization systemmap:SfCWpkO67ty1HLzmK .
 
-systemmap:QxYQ8wqWnYpmVR7FT a systemmap:CantonalOrganization ;
+systemmap:SxYQ8wqWnYpmVR7FT a systemmap:CantonalOrganization ;
     rdfs:label "Strukturverbesserungen und Raumnutzung"@de ;
-    schema:parentOrganization systemmap:QDMGFgrGMHxc0eoLM .
+    schema:parentOrganization systemmap:SDMGFgrGMHxc0eoLM .
 
-systemmap:QyTRdNaA9EH12lhiE a systemmap:CantonalOrganization ;
+systemmap:SyTRdNaA9EH12lhiE a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Solothurn"@de,
         "Canton of Solothurn"@en,
         "Canton de Soleure"@fr,
@@ -1359,7 +1359,7 @@ systemmap:QyTRdNaA9EH12lhiE a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Soletta."@it ;
     systemmap:abbreviation "SO" .
 
-systemmap:QzHOtHCVjJXECjyDj a systemmap:CantonalOrganization ;
+systemmap:SzHOtHCVjJXECjyDj a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Basel-Landschaft"@de,
         "Canton of Basel-Landschaft"@en,
         "Canton de Bâle-Campagne"@fr,
@@ -1370,17 +1370,17 @@ systemmap:QzHOtHCVjJXECjyDj a systemmap:CantonalOrganization ;
         "L'amministrazione cantonale di Basilea Campagna."@it ;
     systemmap:abbreviation "BL" .
 
-systemmap:QY0h92GbLVkapqnQt a systemmap:CantonalVeterinaryService ;
+systemmap:SY0h92GbLVkapqnQt a systemmap:CantonalVeterinaryService ;
     rdfs:label "Kantonaler Veterinärdienst Aargau"@de ;
-    schema:parentOrganization systemmap:Qlsq3Et7cyDrThfMW ;
+    schema:parentOrganization systemmap:Slsq3Et7cyDrThfMW ;
     dcat:landingPage <https://www.ag.ch/de/verwaltung/dgs/verbraucherschutz/veterinaerdienst> .
 
-systemmap:Q1JvEmah9Tl0698au a systemmap:FederalOrganization ;
+systemmap:S1JvEmah9Tl0698au a systemmap:FederalOrganization ;
     rdfs:label "Direktionsbereich für Digitalisierung und Datenmanagement"@de,
         "Directorate for Digitalization and Data Management"@en,
         "Unité de direction Transition numérique et gestion des données"@fr,
         "Unità di direzione Digitalizzazione e gestione dei dati"@it ;
-    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    schema:parentOrganization systemmap:SqeNr0H0FGL6Uv5Rr ;
     rdfs:comment "Der Direktionsbereich Digitalisierung und Datenmanagement setzt sich dafür ein, dass die digitale Transformation und das Datenmanagement in der Land- und Ernährungswirtschaft ziel- und zukunftsgerichtet gefördert werden."@de,
         "The Directorate for Digitalization and Data Management is committed to ensuring that digital transformation and data management in the agricultural and food sector are promoted in a goal-oriented and forward-looking manner."@en,
         "La Direction de la numérisation et de la gestion des données s'engage à ce que la transformation numérique et la gestion des données dans le secteur agricole et alimentaire soient encouragées de manière ciblée et tournée vers l'avenir."@fr,
@@ -1391,7 +1391,7 @@ systemmap:Q1JvEmah9Tl0698au a systemmap:FederalOrganization ;
         "DBDD"@fr,
         "DBDD"@it .
 
-systemmap:Q2QF8BOhJczC0PGhe a systemmap:FederalOrganization ;
+systemmap:S2QF8BOhJczC0PGhe a systemmap:FederalOrganization ;
     rdfs:label "Staatssekretariat für Wirtschaft"@de,
         "State Secretariat for Economic Affairs"@en,
         "Secrétariat d'État à l'économie"@fr,
@@ -1422,7 +1422,7 @@ systemmap:Q2QF8BOhJczC0PGhe a systemmap:FederalOrganization ;
         "SECO"@fr,
         "SECO"@it .
 
-systemmap:Q2tIdqNmt3uS5Ny6D a systemmap:FederalOrganization ;
+systemmap:S2tIdqNmt3uS5Ny6D a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Landwirtschaft"@de,
         "Federal Office for Agriculture"@en,
         "Office fédéral de l'agriculture"@fr,
@@ -1438,7 +1438,7 @@ systemmap:Q2tIdqNmt3uS5Ny6D a systemmap:FederalOrganization ;
         "OFAG"@fr,
         "UFAG"@it .
 
-systemmap:Q3Rf79NI3Pm1rfOlN a systemmap:FederalOrganization ;
+systemmap:S3Rf79NI3Pm1rfOlN a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Lebensmittelsicherheit und Veterinärwesen"@de,
         "Federal Food Safety and Veterinary Office"@en,
         "Office fédéral de la sécurité alimentaire et des affaires vétérinaires"@fr,
@@ -1465,7 +1465,7 @@ systemmap:Q3Rf79NI3Pm1rfOlN a systemmap:FederalOrganization ;
         "OSAV"@fr,
         "USAV"@it .
 
-systemmap:Q8WjMkerPw98ZkWA7 a systemmap:FederalOrganization ;
+systemmap:S8WjMkerPw98ZkWA7 a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Gesundheit"@de,
         "Federal Office of Public Health"@en,
         "Office fédéral de la santé publique"@fr,
@@ -1496,12 +1496,12 @@ systemmap:Q8WjMkerPw98ZkWA7 a systemmap:FederalOrganization ;
         "OFSP"@fr,
         "UFSP"@it .
 
-systemmap:QE8y4MuFWW5BKqK92 a systemmap:FederalOrganization ;
+systemmap:SE8y4MuFWW5BKqK92 a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Agrarinformationssysteme"@de,
         "Agricultural Information Systems Division"@en,
         "Secteur d'information sur l'agriculture"@fr,
         "Settore Sistemi d’informazione sull’agricoltura"@it ;
-    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    schema:parentOrganization systemmap:S1JvEmah9Tl0698au ;
     rdfs:comment "Der Fachbereich Agrarinformationssysteme ist die zentrale Drehscheibe für Agrardaten. Er ist zuständig für das Portal Agate – den Online-Schalter für die Landwirtschaft – sowie für die zentralen Informationssysteme. Er setzt die fachlichen Vorgaben in technische Lösungen um und gewährleistet eine hohe Datenqualität. Dabei setzen wir auf medienbruchfreie, digitale Prozesse und Standards. FBAIS bietet Schnittstellen an für den Bezug und die Weitergabe der Daten an andere Bundesämter und auch an Dritte ausserhalb der Verwaltung."@de,
         "The Agricultural Information Systems Division is the central hub for agricultural data. It is responsible for the Agate portal – the online gateway for agriculture – as well as for central information systems. It implements professional requirements into technical solutions and ensures high data quality. We rely on seamless, digital processes and standards. FBAIS provides interfaces for retrieving and sharing data with other federal offices and third parties outside the administration."@en,
         "L'Unité des systèmes d'information agricole est la plaque tournante centrale des données agricoles. Elle est responsable du portail Agate – la plateforme en ligne pour l'agriculture – ainsi que des systèmes d'information centraux. Elle met en œuvre les exigences professionnelles en solutions techniques et garantit une haute qualité des données. Nous misons sur des processus et des standards numériques sans rupture. FBAIS propose des interfaces pour l'accès et la transmission des données à d'autres offices fédéraux ainsi qu'à des tiers en dehors de l'administration."@fr,
@@ -1511,12 +1511,12 @@ systemmap:QE8y4MuFWW5BKqK92 a systemmap:FederalOrganization ;
         "FBAIS"@fr,
         "FBAIS"@it .
 
-systemmap:QFAwQAwxBcNnaURgO a systemmap:FederalOrganization ;
+systemmap:SFAwQAwxBcNnaURgO a systemmap:FederalOrganization ;
     rdfs:label "Kompetenzzentrum für die digitale Transformation"@de,
         "Competence Center for Digital Transformation"@en,
         "Centre de compétence pour la transformation numérique"@fr,
         "Centro di competenza per la trasformazione digitale"@it ;
-    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    schema:parentOrganization systemmap:S1JvEmah9Tl0698au ;
     rdfs:comment "Das Kompetenzzentrum für die digitale Transformation widmet sich der Standardisierung und Harmonisierung von Daten im Agrar- und Ernährungssektor und ermöglicht deren Mehrfachnutzung nach dem Once-Only-Prinzip. Es führt und koordiniert die digitale Transformation des Sektors, indem es rechtliche, semantische, technische und organisatorische Herausforderungen angeht. Darüber hinaus fördert es die Kommunikation zwischen den Akteuren, um einen reibungslosen und effektiven Übergang zu digitalen Prozessen zu gewährleisten."@de,
         "The Competence Center for Digital Transformation is dedicated to standardizing and harmonizing data in the agri-food sector while enabling multiple data uses through the Once-Only Principle. It leads and coordinates the sector’s digital transformation by addressing legal, semantic, technical, and organizational challenges. Additionally, it fosters communication among stakeholders to ensure a smooth and effective transition to digital processes."@en,
         "Le Centre de compétence pour la transformation numérique se consacre à la standardisation et à l'harmonisation des données dans le secteur agroalimentaire, tout en permettant leur réutilisation multiple selon le principe du « Once-Only ». Il dirige et coordonne la transformation numérique du secteur en relevant les défis juridiques, sémantiques, techniques et organisationnels. De plus, il favorise la communication entre les parties prenantes afin d'assurer une transition fluide et efficace vers des processus numériques."@fr,
@@ -1526,7 +1526,7 @@ systemmap:QFAwQAwxBcNnaURgO a systemmap:FederalOrganization ;
         "GRKDT"@fr,
         "GRKDT"@it .
 
-systemmap:QFKPRpdGa5UISiJlx a systemmap:FederalOrganization ;
+systemmap:SFKPRpdGa5UISiJlx a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Zoll und Grenzsicherheit"@de,
         "Federal Office for Customs and Border Security"@en,
         "Office fédéral de la douane et de la sécurité des frontières"@fr,
@@ -1557,12 +1557,12 @@ systemmap:QFKPRpdGa5UISiJlx a systemmap:FederalOrganization ;
         "OFDF"@fr,
         "UDSC"@it .
 
-systemmap:QFL2DYxeNnVaFsv64 a systemmap:FederalOrganization ;
+systemmap:SFL2DYxeNnVaFsv64 a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Pflanzengesundheit"@de,
         "Plant Health Division"@en,
         "Secteur santé des végétaux"@fr,
         "Settore salute delle piante"@it ;
-    schema:parentOrganization systemmap:QzXI1C2DYjDriK2F8 ;
+    schema:parentOrganization systemmap:SzXI1C2DYjDriK2F8 ;
     rdfs:comment """  
         Die Aufgabe des Fachbereiches Pflanzengesundheit (FBPG) ist es, die Einschleppung und Ausbreitung von (geregelten) besonders gefährlichen Schädlingen und Krankheiten von Pflanzen zu vermeiden.  
         Dies ist wichtig, um wirtschaftliche, soziale und ökologische Schäden zu vermeiden.  
@@ -1588,9 +1588,9 @@ systemmap:QFL2DYxeNnVaFsv64 a systemmap:FederalOrganization ;
         "FBPG"@fr,
         "FBPG"@it .
 
-systemmap:QG8fSveeGZNcYzoUN a systemmap:FederalOrganization ;
+systemmap:SG8fSveeGZNcYzoUN a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Meliorationen"@de ;
-    schema:parentOrganization systemmap:QsJ9OfSkUgPD8dkz3 ;
+    schema:parentOrganization systemmap:SsJ9OfSkUgPD8dkz3 ;
     rdfs:comment """
         Der Fachbereich Meliorationen ist in der Verbundaufgabe mit den Kantonen im ländlichen Tiefbau (Bodenverbesserungen) tätig.
         Er ist bundesintern verfahrensleitende Behörde, beurteilt die Gesuche und übt die Oberaufsicht aus.
@@ -1598,12 +1598,12 @@ systemmap:QG8fSveeGZNcYzoUN a systemmap:FederalOrganization ;
         Weitere Themen sind Management natürlicher Ressourcen, Klimawandel mit Blick auf Boden/Wasserhaushalt.
         """@de .
 
-systemmap:QIo1a8l3IT4lBqBJE a systemmap:FederalOrganization ;
+systemmap:SIo1a8l3IT4lBqBJE a systemmap:FederalOrganization ;
     rdfs:label "Agroscope"@de,
         "Agroscope"@en,
         "Agroscope"@fr,
         "Agroscope"@it ;
-    schema:parentOrganization systemmap:Q2tIdqNmt3uS5Ny6D ;
+    schema:parentOrganization systemmap:S2tIdqNmt3uS5Ny6D ;
     rdfs:comment """
         Agroscope ist das Schweizer Kompetenzzentrum für landwirtschaftliche Forschung und engagiert sich für eine nachhaltige Landwirtschaft, hochwertige Lebensmittelproduktion und Umweltschutz.
         Angeschlossen an das Bundesamt für Landwirtschaft, forscht es entlang der gesamten Wertschöpfungskette der Landwirtschafts- und Ernährungsbranche, von Pflanzenbau und Nutztierhaltung bis hin zu Lebensmitteln und Ernährung.
@@ -1626,12 +1626,12 @@ systemmap:QIo1a8l3IT4lBqBJE a systemmap:FederalOrganization ;
         """@it ;
     owl:sameAs staatskalender:10003634 .
 
-systemmap:QMnIieexlpOQHsGvN a systemmap:FederalOrganization ;
+systemmap:SMnIieexlpOQHsGvN a systemmap:FederalOrganization ;
     rdfs:label "Genetische Ressourcen, Produktionssicherheit und Futtermittel"@de,
         "Genetic Resources, Production Safety and Animal Feed"@en,
         "Ressources génétiques, sécurité de la production et aliments pour animaux"@fr,
         "Risorse genetiche, sicurezza della produzione e mangimi"@it ;
-    schema:parentOrganization systemmap:QzXI1C2DYjDriK2F8 ;
+    schema:parentOrganization systemmap:SzXI1C2DYjDriK2F8 ;
     rdfs:comment """  
         Der Fachbereich Genetische Ressourcen, Produktionssicherheit und Futtermittel ist verantwortlich für den Erhalt und die nachhaltige Nutzung pflanzengenetischer Ressourcen,  
         die Überwachung der Gentechnologie in der Landwirtschaft sowie die Identifikation und Regulierung von Risiken in der landwirtschaftlichen Produktion.  
@@ -1662,7 +1662,7 @@ systemmap:QMnIieexlpOQHsGvN a systemmap:FederalOrganization ;
         "FBGRT"@fr,
         "FBGRT"@it .
 
-systemmap:QNbhMvt3Btta1U1d6 a systemmap:FederalOrganization ;
+systemmap:SNbhMvt3Btta1U1d6 a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Statistik"@de,
         "Federal Statistical Office"@en,
         "Office fédéral de la statistique"@fr,
@@ -1689,12 +1689,12 @@ systemmap:QNbhMvt3Btta1U1d6 a systemmap:FederalOrganization ;
         "OFS"@fr,
         "UST"@it .
 
-systemmap:QQbNLiw8h9MnSXuyo a systemmap:FederalOrganization ;
+systemmap:SQbNLiw8h9MnSXuyo a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Informatikführung"@de,
         "Information Technology Management Division"@en,
         "Secteur Gestion Informatique"@fr,
         "Settore Gestione Informatica"@it ;
-    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    schema:parentOrganization systemmap:S1JvEmah9Tl0698au ;
     rdfs:comment """
         Der Fachbereich Informatikführung verantwortet die strategische Planung, Umsetzung und Sicherheit der Informatik im BLW, einschliesslich des Managements von Projekten, Budgets und Fachanwendungen.
         Er fungiert als Schnittstelle zu Dienstleistern, koordiniert Change-Management-Prozesse und stellt die Ausbildung sowie die Verwaltung von Mutationen und Berechtigungen sicher.
@@ -1717,12 +1717,12 @@ systemmap:QQbNLiw8h9MnSXuyo a systemmap:FederalOrganization ;
         "SGI"@fr,
         "SGI"@it .
 
-systemmap:QRu4rav1Rlm2mUMWr a systemmap:FederalOrganization ;
+systemmap:SRu4rav1Rlm2mUMWr a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Ein- und Ausfuhr"@de,
         "Specialized Unit for Import and Export"@en,
         "Secteur Importations et exportations"@fr,
         "Settore Importazioni ed esportazioni"@it ;
-    schema:parentOrganization systemmap:QhkERubSSrICbOshu ;
+    schema:parentOrganization systemmap:ShkERubSSrICbOshu ;
     rdfs:comment """
         Zu den Hauptaufgaben des Fachbereichs Ein- und Ausfuhr (FBEA) gehören die Verwaltung der Zollkontingente, die Erteilung von Einfuhrbewilligungen, die Zuteilung von Kontingentsanteilen, die Koordination mit der Oberzolldirektion sowie die Durchführung von internen und externen Kontrollen.
         Zudem kümmert sich der FBEA um die Gebührenverwaltung, den Betrieb und die Wartung von Fachapplikationen, die Bearbeitung von Gesuchen im Veredelungsverkehr und um Exportberatungen.
@@ -1743,12 +1743,12 @@ systemmap:QRu4rav1Rlm2mUMWr a systemmap:FederalOrganization ;
     systemmap:abbreviation "FBEA"@de,
         "SIE"@fr .
 
-systemmap:QW5qcGjvfz5WXYTVl a systemmap:FederalOrganization ;
+systemmap:SW5qcGjvfz5WXYTVl a systemmap:FederalOrganization ;
     rdfs:label "Abteilung Lebensmittel und Ernährung"@de,
         "Food and Nutrition Division"@en,
         "Département denrées alimentaires et nutrition"@fr,
         "Dipartimento alimenti e nutrizione"@it ;
-    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    schema:parentOrganization systemmap:S3Rf79NI3Pm1rfOlN ;
     rdfs:comment """
         Die Abteilung Lebensmittel und Ernährung des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) ist verantwortlich für die Sicherheit und Qualität von Lebensmitteln sowie die Förderung einer gesunden Ernährung.
         Sie entwickelt Richtlinien und überwacht die Einhaltung von Standards, um die Gesundheit der Bevölkerung zu schützen.
@@ -1771,12 +1771,12 @@ systemmap:QW5qcGjvfz5WXYTVl a systemmap:FederalOrganization ;
         """@it ;
     owl:sameAs staatskalender:20035162 .
 
-systemmap:QaVyVVsIDkiDMtQq4 a systemmap:FederalOrganization ;
+systemmap:SaVyVVsIDkiDMtQq4 a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Marktanalyse"@de,
         "Market Analysis Division"@en,
         "Secteur analyses du marché"@fr,
         "Settore analisi di mercato"@it ;
-    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    schema:parentOrganization systemmap:S1JvEmah9Tl0698au ;
     rdfs:comment """
         Der Fachbereich Marktanalysen informiert regelmässig über die Preisentwicklung in den Agrarmärkten mit dem Ziel, die Markttransparenz zu erhöhen und langfristige Entwicklungen aufzuzeigen.
         Dazu werden in verschiedenen Marktbereichen Preise entlang der Wertschöpfungsketten erhoben und ausgewiesen sowie datengestützte Marktanalysen erstellt.
@@ -1800,12 +1800,12 @@ systemmap:QaVyVVsIDkiDMtQq4 a systemmap:FederalOrganization ;
     systemmap:hasLegalBasis LwG:art_27,
         <https://www.fedlex.admin.ch/eli/cc/1999/71> .
 
-systemmap:QcVJ3tNOuwZ1juXuE a systemmap:FederalOrganization ;
+systemmap:ScVJ3tNOuwZ1juXuE a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Tierische Produkte und Tierzucht"@de,
         "Sector Animal Products and Breeding"@en,
         "Secteur Produits animaux et élevage"@fr,
         "Settore Prodotti animali e allevamento"@it ;
-    schema:parentOrganization systemmap:QhkERubSSrICbOshu ;
+    schema:parentOrganization systemmap:ShkERubSSrICbOshu ;
     rdfs:comment "Die Mitgestaltung der agrarpolitischen Rahmenbedingungen und deren Weiterentwicklung im Bereich der tierischen Produkte und der Tierzucht gehören zu den Kernaufgaben des FBTT. Weiter stellt er den reibungslosen und korrekten Vollzug der einschlägigen Bestimmungen des Landwirtschaftsgesetzes und folgender Bundesratsverordnungen sicher: Milchpreisstützungsverordnung, Schlachtviehverordnung, Eierverordnung, Verordnung über die Identitas AG und die Tierverkehrsdatenbank, Entsorgungsbeitragsverordnung, Landwirtschaftliche Deklarationsverordnung, Höchstbestandesverordnung, Verordnung über die Branchen- und Produzentenorganisationen, Schafwollverordnung und Tierzuchtverordnung."@de,
         "The design and further development of agricultural policy framework conditions in the field of animal products and breeding are among the core tasks of the SPAE. Furthermore, it ensures the smooth and correct implementation of the relevant provisions of the Agricultural Act and the following Federal Council ordinances: Milk Price Support Ordinance, Slaughter Livestock Ordinance, Egg Ordinance, Ordinance on Identitas AG and the Animal Traffic Database, Disposal Contribution Ordinance, Agricultural Declaration Ordinance, Maximum Stock Ordinance, Ordinance on Sector and Producer Organizations, Sheep Wool Ordinance, and Breeding Ordinance."@en,
         "La conception et le développement des cadres politiques agricoles dans le domaine des produits animaux et de l'élevage font partie des missions principales du SPAE. Il veille également à la mise en œuvre correcte et sans heurts des dispositions pertinentes de la loi agricole et des ordonnances suivantes du Conseil fédéral : Ordonnance sur le soutien des prix du lait, Ordonnance sur le bétail de boucherie, Ordonnance sur les œufs, Ordonnance sur Identitas AG et la base de données sur le trafic des animaux, Ordonnance sur la contribution à l'élimination, Ordonnance sur la déclaration agricole, Ordonnance sur le nombre maximal d'animaux, Ordonnance sur les organisations de filières et de producteurs, Ordonnance sur la laine de mouton et Ordonnance sur l'élevage."@fr,
@@ -1815,17 +1815,17 @@ systemmap:QcVJ3tNOuwZ1juXuE a systemmap:FederalOrganization ;
         "FBTT"@en,
         "SPAE"@fr,
         "SPAA"@it ;
-    systemmap:access systemmap:QLXw4VofhYbzXVNKC,
-        systemmap:Qe6Nt3cqogxz2d10g,
-        systemmap:QoY82Q0qEk9k0s3w3,
-        systemmap:Qutd0KIj3Rf8GlSwq .
+    systemmap:access systemmap:SLXw4VofhYbzXVNKC,
+        systemmap:Se6Nt3cqogxz2d10g,
+        systemmap:SoY82Q0qEk9k0s3w3,
+        systemmap:Sutd0KIj3Rf8GlSwq .
 
-systemmap:QcoeXHl4TgJbke1Yf a systemmap:FederalOrganization ;
+systemmap:ScoeXHl4TgJbke1Yf a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Direktzahlungsgrundlagen"@de,
         "Direct Payment Principles Division"@en,
         "Secteur bases des paiements directs"@fr,
         "Settore basi dei pagamenti diretti"@it ;
-    schema:parentOrganization systemmap:QsJ9OfSkUgPD8dkz3 ;
+    schema:parentOrganization systemmap:SsJ9OfSkUgPD8dkz3 ;
     rdfs:comment """  
         Der Fachbereich Direktzahlungsgrundlagen ist zuständig für die Umsetzung und Weiterentwicklung des Direktzahlungssystems im Bereich der Versorgungssicherheit,  
         der Kulturlandschaft, der Übergangsbeiträge, der landwirtschaftlichen Zonen und Gebiete, der landwirtschaftlichen Begriffe sowie der Anerkennung von Betrieben und Betriebsformen.  
@@ -1851,12 +1851,12 @@ systemmap:QcoeXHl4TgJbke1Yf a systemmap:FederalOrganization ;
         "FBDG"@fr,
         "FBDG"@it .
 
-systemmap:QfX7h09MplFWwb4LK a systemmap:FederalOrganization ;
+systemmap:SfX7h09MplFWwb4LK a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich nachhaltiger Pflanzenschutz und Sorten"@de,
         "Sustainable Plant Protection and Varieties Division"@en,
         "Secteur protection durable des végétaux et variétés"@fr,
         "Settore protezione sostenibile delle piante e varietà"@it ;
-    schema:parentOrganization systemmap:QzXI1C2DYjDriK2F8 ;
+    schema:parentOrganization systemmap:SzXI1C2DYjDriK2F8 ;
     rdfs:comment """  
         Der Fachbereich nachhaltiger Pflanzenschutz und Sorten (FB NPS) sorgt für den Schutz der Kulturen, den Vollzug des Saatgutrechtes und den Sortenschutz.  
         Dabei werden sowohl präventive als auch direkte Pflanzenschutzmassnahmen angewendet, um hochwertige Lebensmittel zu produzieren.  
@@ -1882,12 +1882,12 @@ systemmap:QfX7h09MplFWwb4LK a systemmap:FederalOrganization ;
         "FBNPS"@fr,
         "FBNPS"@it .
 
-systemmap:Qg6T9dU4npL98bHrb a systemmap:FederalOrganization ;
+systemmap:Sg6T9dU4npL98bHrb a systemmap:FederalOrganization ;
     rdfs:label "Abteilung Tiergesundheit und Tierschutz"@de,
         "Animal Health and Welfare Division"@en,
         "Département de la santé et de la protection des animaux"@fr,
         "Dipartimento della salute e della protezione degli animali"@it ;
-    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    schema:parentOrganization systemmap:S3Rf79NI3Pm1rfOlN ;
     rdfs:comment """
         Die Abteilung Tiergesundheit und Tierschutz des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) fördert die Gesundheit und das Wohlbefinden von Tieren.
         Sie arbeitet eng mit Tierhalterorganisationen und Vollzugsorganen zusammen, basierend auf wissenschaftlichen Grundlagen.
@@ -1910,24 +1910,24 @@ systemmap:Qg6T9dU4npL98bHrb a systemmap:FederalOrganization ;
         """@it ;
     owl:sameAs staatskalender:20035164 .
 
-systemmap:QhkERubSSrICbOshu a systemmap:FederalOrganization ;
+systemmap:ShkERubSSrICbOshu a systemmap:FederalOrganization ;
     rdfs:label "Direktionsbereich Märkte und Internationales"@de,
         "Directorate for Markets and International Affairs"@en,
         "Unité de direction Marchés et affaires internationales"@fr,
         "Unità di direzione Mercati e affari internazionali"@it ;
-    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    schema:parentOrganization systemmap:SqeNr0H0FGL6Uv5Rr ;
     rdfs:comment "Der Direktionsbereich Märkte und Internationales setzt sich dafür ein, dass die Landwirtschaft aus dem Verkauf ihrer Produkte eine möglichst hohe Wertschöpfung erzielen kann. Selbsthilfemassnahmen, Innovation und Vermarktung der verschiedenen Branchen werden unterstützt. Zudem engagiert sich dieser Direktionsbereich in internationalen Organisationen wie der UNO-Ernährungsorganisation FAO oder der Welthandelsorganisation WTO."@de,
         "The Directorate for Markets and International Affairs works to ensure that agriculture achieves the highest possible added value from the sale of its products. It supports self-help measures, innovation, and the marketing of various sectors. Additionally, this directorate is involved in international organizations such as the UN Food and Agriculture Organization (FAO) and the World Trade Organization (WTO)."@en,
         "La Direction des marchés et des affaires internationales s'efforce de garantir que l'agriculture tire la plus grande valeur ajoutée possible de la vente de ses produits. Elle soutient les mesures d'auto-assistance, l'innovation et la commercialisation des différentes filières. De plus, cette direction est impliquée dans des organisations internationales telles que l'Organisation des Nations unies pour l'alimentation et l'agriculture (FAO) et l'Organisation mondiale du commerce (OMC)."@fr,
         "La Direzione dei mercati e degli affari internazionali si adopera affinché l'agricoltura ottenga il massimo valore aggiunto possibile dalla vendita dei suoi prodotti. Sostiene misure di auto-aiuto, innovazione e commercializzazione nei vari settori. Inoltre, questa direzione è coinvolta in organizzazioni internazionali come l'Organizzazione delle Nazioni Unite per l'alimentazione e l'agricoltura (FAO) e l'Organizzazione mondiale del commercio (OMC)."@it ;
     systemmap:abbreviation "DBMI"@de .
 
-systemmap:QieZtzwlMAxzFY1op a systemmap:FederalOrganization ;
+systemmap:SieZtzwlMAxzFY1op a systemmap:FederalOrganization ;
     rdfs:label "Business Intelligence Competence Center"@de,
         "Business Intelligence Competence Center"@en,
         "Centre de compétence Business Intelligence"@fr,
         "Centro di competenza Business Intelligence"@it ;
-    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    schema:parentOrganization systemmap:S1JvEmah9Tl0698au ;
     rdfs:comment """  
         Das Business Intelligence Competence Center (BI) ist verantwortlich für die Entwicklung und Umsetzung der BI-Strategie sowie die Planung und Durchführung von BI-Projekten.  
         Zu seinen Aufgaben gehören die Datenvisualisierung, das Reporting, die Beratung und Schulung von BI-Fachanwendern sowie die Analyse, Modellierung und Integration von Daten.  
@@ -1953,12 +1953,12 @@ systemmap:QieZtzwlMAxzFY1op a systemmap:FederalOrganization ;
         "GRBI"@fr,
         "GRBI"@it .
 
-systemmap:QntetIp00hrUGsnj5 a systemmap:FederalOrganization ;
+systemmap:SntetIp00hrUGsnj5 a systemmap:FederalOrganization ;
     rdfs:label "Direktionsbereich Recht, Ressourcen und Integrale Sicherheit"@de,
         "Directorate for Law, Resources, and Integral Security"@en,
         "Unité de direction Droit, ressources internes et sécurité intégrale"@fr,
         "Unità di direzione Digitalizzazione e gestione dei dati"@it ;
-    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    schema:parentOrganization systemmap:SqeNr0H0FGL6Uv5Rr ;
     rdfs:comment "Der Direktionsbereich Recht, Ressourcen und Integrale Sicherheit sichert die rechtliche Konformität der verschiedenen BLW-Massnahmen und ist insbesondere für die personellen Massnahmen des Amtes verantwortlich."@de,
         "The Directorate for Law, Resources, and Integral Security ensures the legal compliance of various BLW measures and is particularly responsible for the office’s personnel measures."@en,
         "La Direction du droit, des ressources et de la sécurité intégrale garantit la conformité juridique des différentes mesures de l'OFAG et est notamment responsable des mesures en matière de personnel du bureau."@fr,
@@ -1968,12 +1968,12 @@ systemmap:QntetIp00hrUGsnj5 a systemmap:FederalOrganization ;
         "DBRRIS"@fr,
         "DBRRIS"@it .
 
-systemmap:QoqmfoevPVgr3d0AA a systemmap:FederalOrganization ;
+systemmap:SoqmfoevPVgr3d0AA a systemmap:FederalOrganization ;
     rdfs:label "Zulassungsstelle Pflanzenschutzmittel"@de,
         "Plant Protection Products Registration Authority"@en,
         "Autorité d'homologation des produits phytosanitaires"@fr,
         "Autorità di omologazione dei prodotti fitosanitari"@it ;
-    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    schema:parentOrganization systemmap:S3Rf79NI3Pm1rfOlN ;
     rdfs:comment """
         Die Zulassungsstelle Pflanzenschutzmittel des Bundesamts für Lebensmittelsicherheit und Veterinärwesen (BLV) ist für die Zulassung und Überprüfung von Pflanzenschutzmitteln in der Schweiz verantwortlich.
         Sie stellt sicher, dass nur sichere und wirksame Pflanzenschutzmittel auf den Markt gelangen, indem sie deren gesundheitliche und ökologische Auswirkungen sorgfältig bewertet.
@@ -1996,12 +1996,12 @@ systemmap:QoqmfoevPVgr3d0AA a systemmap:FederalOrganization ;
         """@it ;
     owl:sameAs staatskalender:20049676 .
 
-systemmap:Qou0GnQeSqCPHGhze a systemmap:FederalOrganization ;
+systemmap:Sou0GnQeSqCPHGhze a systemmap:FederalOrganization ;
     rdfs:label "Abteilung Wissensgrundlagen"@de,
         "Knowledge Foundations Division"@en,
         "Département des bases de connaissances"@fr,
         "Dipartimento delle basi di conoscenza"@it ;
-    schema:parentOrganization systemmap:Q3Rf79NI3Pm1rfOlN ;
+    schema:parentOrganization systemmap:S3Rf79NI3Pm1rfOlN ;
     rdfs:comment """
         Die Abteilung Wissensgrundlagen unterstützt das Bundesamt für Lebensmittelsicherheit und Veterinärwesen (BLV) durch Förderung der Verfügbarkeit und Nutzung von Daten, Kompetenzen, Verfahren und Wissen.
         Sie beurteilt gesundheitliche Risiken für Mensch und Tier und stellt sicher, dass der aktuelle Wissensstand erfasst und bei Bedarf durch externe Expertise ergänzt wird.
@@ -2024,38 +2024,38 @@ systemmap:Qou0GnQeSqCPHGhze a systemmap:FederalOrganization ;
         """@it ;
     owl:sameAs staatskalender:20035163 .
 
-systemmap:QqeNr0H0FGL6Uv5Rr a systemmap:FederalOrganization ;
+systemmap:SqeNr0H0FGL6Uv5Rr a systemmap:FederalOrganization ;
     rdfs:label "Direktion BLW"@de,
         "Directorate FOAG"@en,
         "Direction OFAG"@fr,
         "Direzione UFAG"@it ;
-    schema:parentOrganization systemmap:Q2tIdqNmt3uS5Ny6D ;
+    schema:parentOrganization systemmap:S2tIdqNmt3uS5Ny6D ;
     owl:sameAs staatskalender:10003196 .
 
-systemmap:QsFdxnjM8hgUdzVT5 a systemmap:FederalOrganization ;
+systemmap:SsFdxnjM8hgUdzVT5 a systemmap:FederalOrganization ;
     rdfs:label "Kompetenzzentrum Daten"@de ;
-    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    schema:parentOrganization systemmap:Sou0GnQeSqCPHGhze ;
     owl:sameAs staatskalender:20051877 ;
     systemmap:abbreviation "DCC"@de .
 
-systemmap:QsJ9OfSkUgPD8dkz3 a systemmap:FederalOrganization ;
+systemmap:SsJ9OfSkUgPD8dkz3 a systemmap:FederalOrganization ;
     rdfs:label "Direktionsbereich Direktzahlungen und Ländliche Entwicklung"@de,
         "Directorate for Direct Payments and Rural Development"@en,
         "Unité de direction Paiements directs et développement rural"@fr,
         "Unità di direzione Pagamenti diretti e sviluppo rurale"@it ;
-    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    schema:parentOrganization systemmap:SqeNr0H0FGL6Uv5Rr ;
     rdfs:comment "Die Landwirte und Landwirtinnen erbringen verschiedene Leistungen für die Allgemeinheit und werden deshalb mit finanziellen Beiträgen unterstützt. Dafür ist der Direktionsbereich Direktzahlungen und Ländliche Entwicklung zuständig. Er setzt sich zudem für die Vitalität des ländlichen Raums ein."@de,
         "Farmers provide various services for the general public and are therefore supported with financial contributions. The Directorate for Direct Payments and Rural Development is responsible for this. It also works to ensure the vitality of rural areas."@en,
         "Les agriculteurs fournissent divers services à la collectivité et sont donc soutenus par des contributions financières. La Direction des paiements directs et du développement rural en est responsable. Elle s'engage également pour la vitalité des zones rurales."@fr,
         "Gli agricoltori forniscono vari servizi alla collettività e sono quindi sostenuti con contributi finanziari. La Direzione dei pagamenti diretti e dello sviluppo rurale è responsabile di questo. Inoltre, si impegna per la vitalità delle aree rurali."@it ;
     systemmap:abbreviation "DBDLE"@de .
 
-systemmap:QtL8MElzDJHAjtyXL a systemmap:FederalOrganization ;
+systemmap:StL8MElzDJHAjtyXL a systemmap:FederalOrganization ;
     rdfs:label "Gruppe GEVER Services"@de,
         "GEVER Services Group"@en,
         "Groupe Services GEVER"@fr,
         "Gruppo Servizi GEVER"@it ;
-    schema:parentOrganization systemmap:Q1JvEmah9Tl0698au ;
+    schema:parentOrganization systemmap:S1JvEmah9Tl0698au ;
     rdfs:comment """
         Die Gruppe GEVER Services ist für die physische und elektronische Postverteilung sowie die zentrale Adressverwaltung im BLW zuständig.
         Die Postverarbeitung erfolgt hauptsächlich über das GEVER-System, das eine strukturierte Bearbeitung und Archivierung digitaler Unterlagen ermöglicht. 
@@ -2078,17 +2078,17 @@ systemmap:QtL8MElzDJHAjtyXL a systemmap:FederalOrganization ;
         "GSG"@fr,
         "GSG"@it .
 
-systemmap:QuodJifeNVNW8c4Tj a systemmap:FederalOrganization ;
+systemmap:SuodJifeNVNW8c4Tj a systemmap:FederalOrganization ;
     rdfs:label "Bildung & Forschung"@de ;
-    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    schema:parentOrganization systemmap:Sou0GnQeSqCPHGhze ;
     owl:sameAs staatskalender:20035170 .
 
-systemmap:QvCD295luQEx4jnuB a systemmap:FederalOrganization ;
+systemmap:SvCD295luQEx4jnuB a systemmap:FederalOrganization ;
     rdfs:label "Toxikologie Pflanzenschutzmittel"@de ;
-    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    schema:parentOrganization systemmap:Sou0GnQeSqCPHGhze ;
     owl:sameAs staatskalender:20035173 .
 
-systemmap:QwlgSr7ukziL6iHsP a systemmap:FederalOrganization ;
+systemmap:SwlgSr7ukziL6iHsP a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Umwelt"@de,
         "Federal Office for the Environment"@en,
         "Office fédéral de l'environnement"@fr,
@@ -2119,12 +2119,12 @@ systemmap:QwlgSr7ukziL6iHsP a systemmap:FederalOrganization ;
         "OFEV"@fr,
         "UFAM"@it .
 
-systemmap:QyfZhzeyT1CqJU0BP a systemmap:FederalOrganization ;
+systemmap:SyfZhzeyT1CqJU0BP a systemmap:FederalOrganization ;
     rdfs:label "Fachbereich Direktzahlungsprogramme"@de,
         "Direct Payment Programs Division"@en,
         "Secteur Paiements directs - Programmes"@fr,
         "Settore Pagamenti diretti - Programmi"@it ;
-    schema:parentOrganization systemmap:QsJ9OfSkUgPD8dkz3 ;
+    schema:parentOrganization systemmap:SsJ9OfSkUgPD8dkz3 ;
     rdfs:comment """
         Der Fachbereich setzt Direktzahlungsprogramme in den Bereichen Umwelt, Tierwohl und Landschaft um, unterstützt kantonale Stellen und überwacht deren Vollzug.  
         Zudem wird der ökologische Leistungsnachweis (ÖLN) weiterentwickelt, Regelbereiche wie Biodiversitätsstrategie, Biolandbau sowie Energie- und Klimaschutz koordiniert und relevante Gesetzgebungsschnittstellen gepflegt.  
@@ -2151,17 +2151,17 @@ systemmap:QyfZhzeyT1CqJU0BP a systemmap:FederalOrganization ;
         "FBDP"@fr,
         "FBDP"@it .
 
-systemmap:Qym1u44hA9FMZOdyT a systemmap:FederalOrganization ;
+systemmap:Sym1u44hA9FMZOdyT a systemmap:FederalOrganization ;
     rdfs:label "Risikobewertung"@de ;
-    schema:parentOrganization systemmap:Qou0GnQeSqCPHGhze ;
+    schema:parentOrganization systemmap:Sou0GnQeSqCPHGhze ;
     owl:sameAs staatskalender:20050577 .
 
-systemmap:QzXI1C2DYjDriK2F8 a systemmap:FederalOrganization ;
+systemmap:SzXI1C2DYjDriK2F8 a systemmap:FederalOrganization ;
     rdfs:label "Direktionsbereich Produktionsgrundlagen, natürliche Ressourcen und Forschung"@de,
         "Directorate for Production Resources, Natural Resources and Research"@en,
         "Unité de direction Bases de production, ressources naturelles et recherche"@fr,
         "Unità di direzione Basi di produzione, risorse naturali e ricerca"@it ;
-    schema:parentOrganization systemmap:QqeNr0H0FGL6Uv5Rr ;
+    schema:parentOrganization systemmap:SqeNr0H0FGL6Uv5Rr ;
     rdfs:comment "Widerstandsfähige Produktions- und Ökosysteme stehen im Zentrum des Direktionsbereichs Produktionsgrundlagen, natürliche Ressourcen und Forschung. So ist er unter anderem dafür zuständig, dass Pflanzen nachhaltig geschützt und Tiere optimal ernährt werden können. Desweitern fördert dieser Bereich verschiedene Forschungs- und Beratungsprojekte in der Schweiz, aber auch international."@de,
         "Resilient production and ecosystem systems are at the center of the Directorate for Production Resources, Natural Resources and Research. Among other things, it is responsible for ensuring that plants are sustainably protected and animals are optimally fed. Furthermore, this directorate promotes various research and advisory projects in Switzerland and internationally."@en,
         "Les systèmes de production et les écosystèmes résilients sont au cœur de la Direction des bases de production, des ressources naturelles et de la recherche. Elle est notamment chargée de garantir que les plantes soient protégées durablement et que les animaux soient nourris de manière optimale. De plus, cette direction soutient divers projets de recherche et de conseil en Suisse et à l'international."@fr,
@@ -2174,7 +2174,7 @@ systemmap:QzXI1C2DYjDriK2F8 a systemmap:FederalOrganization ;
 staatskalender:20050530 a systemmap:FederalOrganization ;
     rdfs:label "Monitoring des Agrarumweltsystems Schweiz MAUS"@de .
 
-systemmap:Q3jZwzvmFKsXRWiI a systemmap:Identifier ;
+systemmap:S3jZwzvmFKsXRWiI a systemmap:Identifier ;
     rdfs:label "BUR-Nummer"@de,
         "BUR Number"@en,
         "Numéro BUR"@fr,
@@ -2199,9 +2199,9 @@ systemmap:Q3jZwzvmFKsXRWiI a systemmap:Identifier ;
         "BURNR"@en,
         "BURNR"@fr,
         "BURNR"@it ;
-    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+    systemmap:containedIn systemmap:SHyBeGX0LsQwjJ6Z .
 
-systemmap:QDLEUPczkJ9AWZeC a systemmap:Identifier ;
+systemmap:SDLEUPczkJ9AWZeC a systemmap:Identifier ;
     rdfs:label "UID-Nummer"@de,
         "UID Number"@en,
         "Numéro UID"@fr,
@@ -2222,9 +2222,9 @@ systemmap:QDLEUPczkJ9AWZeC a systemmap:Identifier ;
         Ogni azienda attiva in Svizzera riceve un numero d'identificazione aziendale (UID) unico.
         L'uso dell'UID facilita l'alleggerimento amministrativo per le aziende e consente una collaborazione più efficiente tra le autorità.
         """@it ;
-    systemmap:containedIn systemmap:QuEtT7joC8HXVSfF .
+    systemmap:containedIn systemmap:SuEtT7joC8HXVSfF .
 
-systemmap:Q1AkhvKmzBiJFCTc a systemmap:Information ;
+systemmap:S1AkhvKmzBiJFCTc a systemmap:Information ;
     rdfs:label "Agrarmarktdaten"@de,
         "agricultural market data"@en,
         "données du marché agricole"@fr,
@@ -2233,10 +2233,10 @@ systemmap:Q1AkhvKmzBiJFCTc a systemmap:Information ;
         "Market data includes prices, quantities, production systems."@en,
         "Les données de marché comprennent les prix, les quantités, les systèmes de production."@fr,
         "I dati di mercato comprendono prezzi, quantità e sistemi di produzione."@it ;
-    systemmap:containedIn systemmap:Qc6kZqxTyS0gFGCY ;
-    systemmap:informs systemmap:QRT6X0n1ML8vwHUW .
+    systemmap:containedIn systemmap:Sc6kZqxTyS0gFGCY ;
+    systemmap:informs systemmap:SRT6X0n1ML8vwHUW .
 
-systemmap:Q4BoMPavXD5gIObm a systemmap:Information ;
+systemmap:S4BoMPavXD5gIObm a systemmap:Information ;
     rdfs:label "Tieridentifikationsdaten"@de,
         "Animal identification data"@en,
         "Données d'identification des animaux"@fr,
@@ -2257,9 +2257,9 @@ systemmap:Q4BoMPavXD5gIObm a systemmap:Information ;
         Contiene i dati di identificazione di base degli animali, come i numeri univoci delle marche auricolari, la specie, il sesso e la data di nascita.
         Questi dati principali costituiscono la base per la tracciabilità senza interruzioni nel TVD.
         """@it ;
-    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
+    systemmap:containedIn systemmap:SU88cJmqj8nBRl2KZ .
 
-systemmap:Q4hqylQaEIsYGXMo a systemmap:Information ;
+systemmap:S4hqylQaEIsYGXMo a systemmap:Information ;
     rdfs:label "Verschiebung von Mineraldüngern"@de,
         "Movement of Mineral Fertilizers"@en,
         "Déplacement des engrais minéraux"@fr,
@@ -2276,9 +2276,9 @@ systemmap:Q4hqylQaEIsYGXMo a systemmap:Information ;
         """
         Lo spostamento dei fertilizzanti minerali include la registrazione e la segnalazione di tutti gli afflussi e deflussi di fertilizzanti minerali, compresi acquisti, vendite e trasferimenti interni.
         """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
+    systemmap:containedIn systemmap:SjCVTMrYaOTygNcqF .
 
-systemmap:Q7mhWQjPZiSFc8dU a systemmap:Information ;
+systemmap:S7mhWQjPZiSFc8dU a systemmap:Information ;
     rdfs:label "Tierereignisdaten"@de,
         "Animal event data"@en,
         "Données d'événements animaux"@fr,
@@ -2299,9 +2299,9 @@ systemmap:Q7mhWQjPZiSFc8dU a systemmap:Information ;
         Registra tutti gli eventi dinamici nel ciclo di vita degli animali, inclusi i dati di nascita, movimento e macellazione, nonché i cambi di detentore.
         Queste informazioni sono essenziali per tracciare i cambi di posizione, le fasi di trasporto e i processi di lavorazione.
         """@it ;
-    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
+    systemmap:containedIn systemmap:SU88cJmqj8nBRl2KZ .
 
-systemmap:Q8JpqvyO4LQwEM5s a systemmap:Information ;
+systemmap:S8JpqvyO4LQwEM5s a systemmap:Information ;
     rdfs:label "Globaler Sortenkatalog"@de,
         "Global variety catalog"@en,
         "Catalogue mondial des variétés"@fr,
@@ -2321,10 +2321,10 @@ systemmap:Q8JpqvyO4LQwEM5s a systemmap:Information ;
         Informazioni sulle varietà vegetali provenienti dai paesi membri dell'UPOV e dall'Organizzazione per la cooperazione e lo sviluppo economico (OCSE).
         Questo elenco di varietà funge da registro centrale per le denominazioni varietali e supporta la verifica della distinzione delle nuove varietà.
         """@it ;
-    systemmap:containedIn systemmap:QgjZ0efLbuCR2HvN ;
-    systemmap:informedBy systemmap:Qpqrv6Ul05KJySTs .
+    systemmap:containedIn systemmap:SgjZ0efLbuCR2HvN ;
+    systemmap:informedBy systemmap:Spqrv6Ul05KJySTs .
 
-systemmap:Q8cKNg0hfPy97TUB a systemmap:Information ;
+systemmap:S8cKNg0hfPy97TUB a systemmap:Information ;
     rdfs:label "Details zu Unternehmen"@de,
         "Company details"@en,
         "Détails sur les entreprises"@fr,
@@ -2341,9 +2341,9 @@ systemmap:Q8cKNg0hfPy97TUB a systemmap:Information ;
         """
         Numero di dipendenti per genere e orario di lavoro, capitale sociale delle società per azioni, dati di fatturato, data di registrazione o cancellazione nel registro commerciale, data di annuncio della fondazione o chiusura di un'azienda o impresa.
         """@it ;
-    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+    systemmap:containedIn systemmap:SHyBeGX0LsQwjJ6Z .
 
-systemmap:Q9J1HTMKIxnCgmYc a systemmap:Information ;
+systemmap:S9J1HTMKIxnCgmYc a systemmap:Information ;
     rdfs:label "Pflanzenschutzmittel"@de,
         "Plant Protection Products"@en,
         "Produits phytosanitaires"@fr,
@@ -2360,9 +2360,9 @@ systemmap:Q9J1HTMKIxnCgmYc a systemmap:Information ;
         """
         Elenco dei prodotti fitosanitari autorizzati in Svizzera, inclusa la loro composizione chimica, i numeri W e i titolari dell'autorizzazione.
         """@it ;
-    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
+    systemmap:containedIn systemmap:Shhoiq8azX3SHGL3W .
 
-systemmap:QAUWzyCpeGZ6vVil a systemmap:Information ;
+systemmap:SAUWzyCpeGZ6vVil a systemmap:Information ;
     rdfs:label "Daten zu Tierhaltern"@de,
         "Data on animal owners"@en,
         "Données sur les détenteurs d’animaux"@fr,
@@ -2387,10 +2387,10 @@ systemmap:QAUWzyCpeGZ6vVil a systemmap:Information ;
         Ciò include i dati di identificazione necessari per l'assegnazione univoca, come il numero TVD o il numero dell'azienda agricola, nonché i dati di base sull'identità e l'indirizzo di contatto della persona.
         Questi dati garantiscono che tutti i movimenti e gli eventi degli animali possano essere correttamente attribuiti a un detentore, essenziale per la tracciabilità e il rispetto dei requisiti legali.
         """@it ;
-    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ ;
-    systemmap:informedBy systemmap:QvNriWslaOR5xkdw .
+    systemmap:containedIn systemmap:SU88cJmqj8nBRl2KZ ;
+    systemmap:informedBy systemmap:SvNriWslaOR5xkdw .
 
-systemmap:QDmJeWK7EOnMqRLs a systemmap:Information ;
+systemmap:SDmJeWK7EOnMqRLs a systemmap:Information ;
     rdfs:label "Auflagen zur Anwendung von Pflanzenschutzmitteln"@de,
         "Conditions for the Use of Plant Protection Products"@en,
         "Conditions d'utilisation des produits phytosanitaires"@fr,
@@ -2407,9 +2407,9 @@ systemmap:QDmJeWK7EOnMqRLs a systemmap:Information ;
         """
         Regolamenti e restrizioni da osservare nell'uso dei prodotti fitosanitari, inclusi dosaggio, tempistica dell'applicazione e misure protettive.
         """@it ;
-    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
+    systemmap:containedIn systemmap:Shhoiq8azX3SHGL3W .
 
-systemmap:QECM4KqStG9yBva6 a systemmap:Information ;
+systemmap:SECM4KqStG9yBva6 a systemmap:Information ;
     rdfs:label "Verschiebung von Hof- und Recyclingdünger"@de,
         "Movement of Farmyard and Recycled Fertilizers"@en,
         "Déplacement des engrais de ferme et recyclés"@fr,
@@ -2426,9 +2426,9 @@ systemmap:QECM4KqStG9yBva6 a systemmap:Information ;
         """
         Lo spostamento dei fertilizzanti aziendali e riciclati include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
         """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
+    systemmap:containedIn systemmap:SjCVTMrYaOTygNcqF .
 
-systemmap:QFyGV7l0kN4qgA8u a systemmap:Information ;
+systemmap:SFyGV7l0kN4qgA8u a systemmap:Information ;
     rdfs:label "Kulturen und Schaderreger"@de,
         "Crops and Pests"@en,
         "Cultures et organismes nuisibles"@fr,
@@ -2445,9 +2445,9 @@ systemmap:QFyGV7l0kN4qgA8u a systemmap:Information ;
         """
         Elenco delle colture e degli organismi nocivi per i quali è già stata concessa un'autorizzazione per un prodotto fitosanitario in Svizzera.
         """@it ;
-    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
+    systemmap:containedIn systemmap:Shhoiq8azX3SHGL3W .
 
-systemmap:QIsQ6LSUJc3xbG9B a systemmap:Information ;
+systemmap:SIsQ6LSUJc3xbG9B a systemmap:Information ;
     rdfs:label "Biozide"@de,
         "Biocides"@en,
         "Biocides"@fr,
@@ -2464,9 +2464,9 @@ systemmap:QIsQ6LSUJc3xbG9B a systemmap:Information ;
         """
         Prodotti utilizzati per combattere gli organismi nocivi. Sono inclusi anche i prodotti fitosanitari importati parallelamente da altri paesi.
         """@it ;
-    systemmap:containedIn systemmap:QHEaRYIgvZ3xrDLo .
+    systemmap:containedIn systemmap:SHEaRYIgvZ3xrDLo .
 
-systemmap:QLXw4VofhYbzXVNKC a systemmap:Information ;
+systemmap:SLXw4VofhYbzXVNKC a systemmap:Information ;
     rdfs:label "Daten zur Milchverwertung"@de,
         "Data on milk utilization"@en,
         "Données sur la valorisation du lait"@fr,
@@ -2475,9 +2475,9 @@ systemmap:QLXw4VofhYbzXVNKC a systemmap:Information ;
         "These data are essential for the calculation and payment of subsidies for cheesed milk as well as for feeding without silage by the Federal Office for Agriculture (BLW)."@en,
         "Ces données sont essentielles pour le calcul et le paiement des subventions pour le lait transformé en fromage ainsi que pour l'alimentation sans ensilage par l'Office fédéral de l'agriculture (OFAG)."@fr,
         "Questi dati sono essenziali per il calcolo e il pagamento dei sussidi per il latte trasformato in formaggio e per l'alimentazione senza insilato da parte dell'Ufficio federale dell'agricoltura (UFAG)."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP .
 
-systemmap:QPCig1xdekUHDV4r a systemmap:Information ;
+systemmap:SPCig1xdekUHDV4r a systemmap:Information ;
     rdfs:label "Milchstatistik"@de,
         "Milk statistics"@en,
         "Statistiques du lait"@fr,
@@ -2486,17 +2486,17 @@ systemmap:QPCig1xdekUHDV4r a systemmap:Information ;
         "Monthly statistics and multi-year comparisons containing information on the milk produced and its processing into different product groups."@en,
         "Statistiques mensuelles et comparaisons pluriannuelles contenant des informations sur le lait produit et sa transformation en différentes catégories de produits."@fr,
         "Statistiche mensili e confronti pluriennali contenenti informazioni sul latte prodotto e sulla sua trasformazione in diverse categorie di prodotti."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP .
 
-systemmap:QRT6X0n1ML8vwHUW a systemmap:Information ;
+systemmap:SRT6X0n1ML8vwHUW a systemmap:Information ;
     rdfs:label "Linked Data"@de,
         "Linked Data"@en,
         "Linked Data"@fr,
         "Linked Data"@it ;
-    systemmap:containedIn systemmap:QHFSc6xgsHF70IlUd,
-        systemmap:QpLZd1ojPxF0CvH28 .
+    systemmap:containedIn systemmap:SHFSc6xgsHF70IlUd,
+        systemmap:SpLZd1ojPxF0CvH28 .
 
-systemmap:QUZP05KJlIyCX9A8 a systemmap:Information ;
+systemmap:SUZP05KJlIyCX9A8 a systemmap:Information ;
     rdfs:label "Zubereitungen"@de,
         "Preparations"@en,
         "Préparations"@fr,
@@ -2513,9 +2513,9 @@ systemmap:QUZP05KJlIyCX9A8 a systemmap:Information ;
         """
         Miscele o soluzioni composte da due o più sostanze.
         """@it ;
-    systemmap:containedIn systemmap:QHEaRYIgvZ3xrDLo .
+    systemmap:containedIn systemmap:SHEaRYIgvZ3xrDLo .
 
-systemmap:QUlfRYzH3b0gx7VX a systemmap:Information ;
+systemmap:SUlfRYzH3b0gx7VX a systemmap:Information ;
     rdfs:label "Verschiebung von Pflanzenschutzmitteln"@de,
         "Movement of Plant Protection Products"@en,
         "Déplacement des produits phytosanitaires"@fr,
@@ -2532,9 +2532,9 @@ systemmap:QUlfRYzH3b0gx7VX a systemmap:Information ;
         """
         Lo spostamento dei prodotti fitosanitari include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
         """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
+    systemmap:containedIn systemmap:SjCVTMrYaOTygNcqF .
 
-systemmap:QZBHsREMx369FArg a systemmap:Information ;
+systemmap:SZBHsREMx369FArg a systemmap:Information ;
     rdfs:label "Dünger"@de,
         "Fertilizers"@en,
         "Engrais"@fr,
@@ -2551,9 +2551,9 @@ systemmap:QZBHsREMx369FArg a systemmap:Information ;
         """
         Prodotti per la fertilizzazione del suolo e delle piante.
         """@it ;
-    systemmap:containedIn systemmap:QHEaRYIgvZ3xrDLo .
+    systemmap:containedIn systemmap:SHEaRYIgvZ3xrDLo .
 
-systemmap:Qb2FM7pKN60PrRwU a systemmap:Information ;
+systemmap:Sb2FM7pKN60PrRwU a systemmap:Information ;
     rdfs:label "Globale Pflanzenliste"@de,
         "Global plant list"@en,
         "Liste globale des plantes"@fr,
@@ -2582,9 +2582,9 @@ systemmap:Qb2FM7pKN60PrRwU a systemmap:Information ;
         Questi cosiddetti codici UPOV sono generalmente composti da cinque lettere per il genere e tre lettere per la specie. Ad esempio, <tt>PRUNU_ARM</tt> rappresenta <i>Prunus armeniaca</i> (albicocco).
         Questo sistema facilita la classificazione e lo scambio di informazioni sulle varietà vegetali.
         """@it ;
-    systemmap:containedIn systemmap:QgjZ0efLbuCR2HvN .
+    systemmap:containedIn systemmap:SgjZ0efLbuCR2HvN .
 
-systemmap:Qe6Nt3cqogxz2d10g a systemmap:Information ;
+systemmap:Se6Nt3cqogxz2d10g a systemmap:Information ;
     rdfs:label "Daten zur Milchproduktion"@de,
         "Data on milk production"@en,
         "Données sur la production laitière"@fr,
@@ -2605,9 +2605,9 @@ systemmap:Qe6Nt3cqogxz2d10g a systemmap:Information ;
         Quantità di produzione mensili (in kg) del latte di mucca e bufala consegnato nel mese precedente da tutti i produttori di latte.
         L'UFAG necessita di queste informazioni per l'assegnazione del sussidio per il latte di consumo.
         """@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP .
 
-systemmap:Ql5KyePu7JtGiE3V a systemmap:Information ;
+systemmap:Sl5KyePu7JtGiE3V a systemmap:Information ;
     rdfs:label "Produktekatalog"@de,
         "Product catalog"@en,
         "Catalogue de produits"@fr,
@@ -2628,11 +2628,11 @@ systemmap:Ql5KyePu7JtGiE3V a systemmap:Information ;
         Raccolta di informazioni sui prodotti fitosanitari, i mangimi, i fertilizzanti minerali, i fertilizzanti agricoli e quelli riciclati.
         Ciò include gli identificatori, i nomi, le descrizioni, gli ingredienti e le quantità, ecc.
         """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF ;
-    systemmap:informedBy systemmap:Q9J1HTMKIxnCgmYc,
-        systemmap:QZBHsREMx369FArg .
+    systemmap:containedIn systemmap:SjCVTMrYaOTygNcqF ;
+    systemmap:informedBy systemmap:S9J1HTMKIxnCgmYc,
+        systemmap:SZBHsREMx369FArg .
 
-systemmap:QoBRgq7STLbZfEze a systemmap:Information ;
+systemmap:SoBRgq7STLbZfEze a systemmap:Information ;
     rdfs:label "Meldepflichtdaten (Schafe & Ziegen)"@de,
         "Mandatory reporting data (sheep & goats)"@en,
         "Données à déclaration obligatoire (moutons & chèvres)"@fr,
@@ -2653,9 +2653,9 @@ systemmap:QoBRgq7STLbZfEze a systemmap:Information ;
         Contiene dati specifici che devono essere registrati a causa di obblighi di notifica estesi per pecore e capre.
         Ciò include le segnalazioni di nascite (entro 30 giorni), nonché decessi, arrivi e partenze e macellazioni (entro 3 giorni).
         """@it ;
-    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
+    systemmap:containedIn systemmap:SU88cJmqj8nBRl2KZ .
 
-systemmap:Qpqrv6Ul05KJySTs a systemmap:Information ;
+systemmap:Spqrv6Ul05KJySTs a systemmap:Information ;
     rdfs:label "Nationaler Sortenkatalog"@de,
         "National variety catalog"@en,
         "Catalogue national des variétés"@fr,
@@ -2664,10 +2664,10 @@ systemmap:Qpqrv6Ul05KJySTs a systemmap:Information ;
         "Catalog of recognized agricultural plant varieties used in Switzerland. The information is recorded by breeders."@en,
         "Catalogue des variétés de plantes agricoles reconnues utilisées en Suisse. Les informations sont enregistrées par les sélectionneurs."@fr,
         "Catalogo delle varietà di piante agricole riconosciute utilizzate in Svizzera. Le informazioni sono registrate dai selezionatori."@it ;
-    systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj ;
-    systemmap:informedBy systemmap:Qb2FM7pKN60PrRwU .
+    systemmap:containedIn systemmap:SE5DY78J7vgfoiDLj ;
+    systemmap:informedBy systemmap:Sb2FM7pKN60PrRwU .
 
-systemmap:QzcK9O3XZFxVW1IS a systemmap:Information ;
+systemmap:SzcK9O3XZFxVW1IS a systemmap:Information ;
     rdfs:label "Daten zur Milchsegmentierung"@de,
         "Data on milk segmentation"@en,
         "Données sur la segmentation du lait"@fr,
@@ -2676,9 +2676,9 @@ systemmap:QzcK9O3XZFxVW1IS a systemmap:Information ;
         "Data on the segmentation of milk utilization according to the BOM1 regulation."@en,
         "Données sur la segmentation de la valorisation du lait selon le règlement BOM1."@fr,
         "Dati sulla segmentazione dell'utilizzo del latte secondo il regolamento BOM1."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP .
 
-systemmap:QzuDlnYUQMk3HaCb a systemmap:Information ;
+systemmap:SzuDlnYUQMk3HaCb a systemmap:Information ;
     rdfs:label "Strukturdaten"@de,
         "Structural data"@en,
         "Données structurelles"@fr,
@@ -2703,10 +2703,10 @@ systemmap:QzuDlnYUQMk3HaCb a systemmap:Information ;
         Copre quasi il 100% delle aziende e raccoglie variabili come le dimensioni aziendali, le superfici coltivate, il numero di animali da allevamento e gli occupati.
         L'indagine serve per l'analisi statistica dell'agricoltura, l'aggiornamento del registro delle aziende e le decisioni di politica agricola.
         """@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
-    systemmap:informs systemmap:QX1qchbxSZKWI6Up .
+    systemmap:containedIn systemmap:SvDlxaJ5YMkuZGH6k ;
+    systemmap:informs systemmap:SX1qchbxSZKWI6Up .
 
-systemmap:Q6ILF4g1j5sNf9aG a systemmap:PersonInformation ;
+systemmap:S6ILF4g1j5sNf9aG a systemmap:PersonInformation ;
     rdfs:label "Informationen zur Einfuhr von PSM"@de,
         "Information on the import of PPP"@en,
         "Informations sur l'importation de PPP"@fr,
@@ -2723,10 +2723,10 @@ systemmap:Q6ILF4g1j5sNf9aG a systemmap:PersonInformation ;
         """
         Informazioni sulla data di importazione, il prodotto, l'importatore e il destinatario di un prodotto fitosanitario (PPP).
         """@it ;
-    systemmap:containedIn systemmap:QywklUB91myTH0cvS ;
-    systemmap:informedBy systemmap:QfQ6BN8rDjKhTWL4 .
+    systemmap:containedIn systemmap:SywklUB91myTH0cvS ;
+    systemmap:informedBy systemmap:SfQ6BN8rDjKhTWL4 .
 
-systemmap:Q6aBblr7qNp15tGw a systemmap:PersonInformation ;
+systemmap:S6aBblr7qNp15tGw a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Bewirtschaftenden"@de,
         "Contact details of farm managers"@en,
         "Coordonnées des exploitants agricoles"@fr,
@@ -2735,9 +2735,9 @@ systemmap:Q6aBblr7qNp15tGw a systemmap:PersonInformation ;
         "Information on the contact details of farm managers, such as email addresses or phone numbers."@en,
         "Informations sur les coordonnées des exploitants agricoles, telles que les adresses e-mail ou les numéros de téléphone."@fr,
         "Informazioni sui dati di contatto dei gestori agricoli, come indirizzi e-mail o numeri di telefono."@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
+    systemmap:containedIn systemmap:SvDlxaJ5YMkuZGH6k .
 
-systemmap:QJuklUVKfEwj2Xpc a systemmap:PersonInformation ;
+systemmap:SJuklUVKfEwj2Xpc a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Züchter"@de,
         "Contact details of breeders"@en,
         "Coordonnées des sélectionneurs"@fr,
@@ -2746,9 +2746,9 @@ systemmap:QJuklUVKfEwj2Xpc a systemmap:PersonInformation ;
         "Contact details of breeders who provide information about the varieties to ProVar."@en,
         "Coordonnées des sélectionneurs qui fournissent des informations sur les variétés à ProVar."@fr,
         "Dati di contatto dei selezionatori che forniscono informazioni sulle varietà a ProVar."@it ;
-    systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj .
+    systemmap:containedIn systemmap:SE5DY78J7vgfoiDLj .
 
-systemmap:QQ2MIhpz1CvdqK6f a systemmap:PersonInformation ;
+systemmap:SQ2MIhpz1CvdqK6f a systemmap:PersonInformation ;
     rdfs:label "Beitragsdaten"@de,
         "Contribution data"@en,
         "Données de contribution"@fr,
@@ -2769,9 +2769,9 @@ systemmap:QQ2MIhpz1CvdqK6f a systemmap:PersonInformation ;
         Contiene dati sui contributi finanziari alle aziende agricole.
         Ciò include informazioni sugli importi dei contributi, le basi di calcolo, i criteri e le modalità di pagamento, nonché i processi amministrativi sottostanti.
         """@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
+    systemmap:containedIn systemmap:SvDlxaJ5YMkuZGH6k .
 
-systemmap:QX1qchbxSZKWI6Up a systemmap:PersonInformation ;
+systemmap:SX1qchbxSZKWI6Up a systemmap:PersonInformation ;
     rdfs:label "Informationen zu Landwirtschaftsbetrieben"@de,
         "Information about agricultural enterprises"@en,
         "Informations sur les exploitations agricoles"@fr,
@@ -2780,16 +2780,16 @@ systemmap:QX1qchbxSZKWI6Up a systemmap:PersonInformation ;
         "Number of large livestock units, information on land use, occupation and age of the farm manager."@en,
         "Nombre d'unités de gros bétail, informations sur l'utilisation des sols, la profession et l'âge du directeur ou de la directrice d'exploitation."@fr,
         "Numero di unità di bestiame grosso, informazioni sull'uso del suolo, la professione e l'età del gestore aziendale."@it ;
-    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+    systemmap:containedIn systemmap:SHyBeGX0LsQwjJ6Z .
 
-systemmap:QY9n2yTOBWXtZ6se a systemmap:PersonInformation ;
+systemmap:SY9n2yTOBWXtZ6se a systemmap:PersonInformation ;
     rdfs:label "Daten über Kontrollen und Kontrollergebnisse"@de,
         "Data on inspections and inspection results"@en,
         "Données sur les contrôles et les résultats des contrôles"@fr,
         "Dati sui controlli e sui risultati dei controlli"@it ;
-    systemmap:containedIn systemmap:Q9VcxLSoIIwQjoexY .
+    systemmap:containedIn systemmap:S9VcxLSoIIwQjoexY .
 
-systemmap:QYlOxcohgWiXr61M a systemmap:PersonInformation ;
+systemmap:SYlOxcohgWiXr61M a systemmap:PersonInformation ;
     rdfs:label "Informationen zu Forstbetrieben"@de,
         "Information about forestry enterprises"@en,
         "Informations sur les entreprises forestières"@fr,
@@ -2798,21 +2798,21 @@ systemmap:QYlOxcohgWiXr61M a systemmap:PersonInformation ;
         "Number of employed persons by gender and working time."@en,
         "Nombre de personnes employées selon le sexe et le temps de travail."@fr,
         "Numero di persone impiegate per genere e orario di lavoro."@it ;
-    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+    systemmap:containedIn systemmap:SHyBeGX0LsQwjJ6Z .
 
-systemmap:QakCt52w8AKrsSXi a systemmap:PersonInformation ;
+systemmap:SakCt52w8AKrsSXi a systemmap:PersonInformation ;
     rdfs:label "Informationen der Strukturdatenerhebung"@de,
         "Information from the structural data survey"@en,
         "Informations de l'enquête sur les données structurelles"@fr,
         "Informazioni dall'indagine sui dati strutturali"@it ;
-    systemmap:containedIn systemmap:QMjqlEoVCR9wpTyN1,
-        systemmap:QPWOFHR512FuAc25b,
-        systemmap:QZ9LRAuSt2EOvBpqY,
-        systemmap:QmWEQ8lVlDS9ZwPkY,
-        systemmap:QpR2aDraNmiUXz55J ;
-    systemmap:informs systemmap:QzuDlnYUQMk3HaCb .
+    systemmap:containedIn systemmap:SMjqlEoVCR9wpTyN1,
+        systemmap:SPWOFHR512FuAc25b,
+        systemmap:SZ9LRAuSt2EOvBpqY,
+        systemmap:SmWEQ8lVlDS9ZwPkY,
+        systemmap:SpR2aDraNmiUXz55J ;
+    systemmap:informs systemmap:SzuDlnYUQMk3HaCb .
 
-systemmap:QeUFazO70bpqCYJ5 a systemmap:PersonInformation ;
+systemmap:SeUFazO70bpqCYJ5 a systemmap:PersonInformation ;
     rdfs:label "Stammdaten und Identifikatoren"@de,
         "Master data and identifiers"@en,
         "Données de base et identifiants"@fr,
@@ -2821,9 +2821,9 @@ systemmap:QeUFazO70bpqCYJ5 a systemmap:PersonInformation ;
         "Name and address of the company or business, municipality numbers, BUR number (non-speaking 8-digit identification number), company identification number (UID), type of economic activity (NOGA), legal form of the company."@en,
         "Nom et adresse de l'entreprise ou de l'exploitation, numéros de commune, numéro BUR (numéro d'identification à 8 chiffres non parlant), numéro d'identification de l'entreprise (UID), type d'activité économique (NOGA), forme juridique de l'entreprise."@fr,
         "Nome e indirizzo dell'azienda o dell'impresa, numeri dei comuni, numero BUR (numero di identificazione a 8 cifre non parlante), numero di identificazione aziendale (UID), tipo di attività economica (NOGA), forma giuridica dell'azienda."@it ;
-    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+    systemmap:containedIn systemmap:SHyBeGX0LsQwjJ6Z .
 
-systemmap:QfQ6BN8rDjKhTWL4 a systemmap:PersonInformation ;
+systemmap:SfQ6BN8rDjKhTWL4 a systemmap:PersonInformation ;
     rdfs:label "Pflanzenschutzmittel-Importe"@de,
         "Pesticide imports"@en,
         "Importations de produits phytosanitaires"@fr,
@@ -2840,9 +2840,9 @@ systemmap:QfQ6BN8rDjKhTWL4 a systemmap:PersonInformation ;
         """
         Dati su ogni importazione di prodotti fitosanitari, compresi UID e nome dell'importatore, data di importazione, quantità importata, denominazione del prodotto (testo libero) e indirizzo di consegna.
         """@it ;
-    systemmap:containedIn systemmap:Q7u1Bh6qfXUbSDkv .
+    systemmap:containedIn systemmap:S7u1Bh6qfXUbSDkv .
 
-systemmap:QldiTYOuXQmoC3SV a systemmap:PersonInformation ;
+systemmap:SldiTYOuXQmoC3SV a systemmap:PersonInformation ;
     rdfs:label "Anmeldungen für Direktzahlungsarten"@de,
         "Registrations for direct payment types"@en,
         "Inscriptions pour les types de paiements directs"@fr,
@@ -2863,9 +2863,9 @@ systemmap:QldiTYOuXQmoC3SV a systemmap:PersonInformation ;
         Copre il processo e i dati relativi alla registrazione per diversi tipi di pagamenti diretti.
         Include informazioni sulle procedure di iscrizione, le scadenze, i requisiti e i moduli utilizzati per la richiesta.
         """@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
+    systemmap:containedIn systemmap:SvDlxaJ5YMkuZGH6k .
 
-systemmap:QoY82Q0qEk9k0s3w3 a systemmap:PersonInformation ;
+systemmap:SoY82Q0qEk9k0s3w3 a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Milchproduzenten"@de,
         "Contact details of milk producers"@en,
         "Coordonnées des producteurs de lait"@fr,
@@ -2874,10 +2874,10 @@ systemmap:QoY82Q0qEk9k0s3w3 a systemmap:PersonInformation ;
         "Contact details of milk producers, such as addresses, TVD number, AGIS number of the farm, AGIS number of the operator, and payment information for the subsidy for cheesed milk and the subsidy for feeding without silage. If possible, these contact details are obtained from AGIS."@en,
         "Coordonnées des producteurs de lait, telles que les adresses, le numéro TVD, le numéro AGIS de l'exploitation, le numéro AGIS de l'exploitant et les informations de paiement pour la subvention pour le lait transformé en fromage et la subvention pour l'alimentation sans ensilage. Si possible, ces coordonnées sont obtenues auprès d'AGIS."@fr,
         "Dati di contatto dei produttori di latte, come indirizzi, numero TVD, numero AGIS dell'azienda, numero AGIS del gestore e informazioni di pagamento per il sussidio per il latte trasformato in formaggio e il sussidio per l'alimentazione senza insilato. Se possibile, questi dati di contatto vengono ottenuti da AGIS."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP ;
-    systemmap:informedBy systemmap:Q6aBblr7qNp15tGw .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP ;
+    systemmap:informedBy systemmap:S6aBblr7qNp15tGw .
 
-systemmap:Qutd0KIj3Rf8GlSwq a systemmap:PersonInformation ;
+systemmap:Sutd0KIj3Rf8GlSwq a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Milchverarbeiter"@de,
         "Contact details of milk processors"@en,
         "Coordonnées des transformateurs de lait"@fr,
@@ -2886,9 +2886,9 @@ systemmap:Qutd0KIj3Rf8GlSwq a systemmap:PersonInformation ;
         "Contact details of milk processors, such as addresses or identification numbers."@en,
         "Coordonnées des transformateurs de lait, telles que les adresses ou les numéros d'identification."@fr,
         "Dati di contatto dei trasformatori di latte, come indirizzi o numeri di identificazione."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP .
 
-systemmap:QvNriWslaOR5xkdw a systemmap:PersonInformation ;
+systemmap:SvNriWslaOR5xkdw a systemmap:PersonInformation ;
     rdfs:label "Betriebsdaten (Person, Betrieb)"@de,
         "Operational data (Person, Business)"@en,
         "Données opérationnelles (Personne, Entreprise)"@fr,
@@ -2897,12 +2897,12 @@ systemmap:QvNriWslaOR5xkdw a systemmap:PersonInformation ;
         "Contains basic information about agricultural businesses and related individuals. This includes identification data, organizational structures, and details about individuals involved in the business (e.g., farm managers, family members, and employees)."@en,
         "Contient des informations de base sur les exploitations agricoles et les personnes associées. Cela inclut les données d'identification, les structures organisationnelles et les détails sur les personnes impliquées dans l'exploitation (p. ex. gestionnaires de ferme, membres de la famille et employés)."@fr,
         "Contiene informazioni di base sulle aziende agricole e sulle persone ad esse associate. Ciò include dati identificativi, strutture organizzative e dettagli sulle persone coinvolte nell'azienda (ad es. gestori dell'azienda, familiari e dipendenti)."@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
-    systemmap:informs systemmap:QX1qchbxSZKWI6Up ;
-    systemmap:usesIdentifier systemmap:Q3jZwzvmFKsXRWiI,
-        systemmap:QDLEUPczkJ9AWZeC .
+    systemmap:containedIn systemmap:SvDlxaJ5YMkuZGH6k ;
+    systemmap:informs systemmap:SX1qchbxSZKWI6Up ;
+    systemmap:usesIdentifier systemmap:S3jZwzvmFKsXRWiI,
+        systemmap:SDLEUPczkJ9AWZeC .
 
-systemmap:QDetpcQhSMo4IAeAb a systemmap:PrivateOrganization ;
+systemmap:SDetpcQhSMo4IAeAb a systemmap:PrivateOrganization ;
     rdfs:label "Barto AG"@de,
         "Barto AG"@en,
         "Barto AG"@fr,
@@ -2931,9 +2931,9 @@ systemmap:QDetpcQhSMo4IAeAb a systemmap:PrivateOrganization ;
         La piattaforma integra varie funzioni agronomiche e amministrative e consente una gestione efficiente delle risorse.
         Barto AG collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
         """@it ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
-systemmap:QFAcWHo27bji7sVts a systemmap:PrivateOrganization ;
+systemmap:SFAcWHo27bji7sVts a systemmap:PrivateOrganization ;
     rdfs:label "Fenaco Genossenschaft"@de,
         "Fenaco Cooperative"@en,
         "Coopérative Fenaco"@fr,
@@ -2964,7 +2964,7 @@ systemmap:QFAcWHo27bji7sVts a systemmap:PrivateOrganization ;
         """@it ;
     owl:sameAs zefix:328631 .
 
-systemmap:QHObqf1JYpt7KGLFS a systemmap:PrivateOrganization ;
+systemmap:SHObqf1JYpt7KGLFS a systemmap:PrivateOrganization ;
     rdfs:label "Identitas AG"@de,
         "Identitas AG"@en,
         "Identitas AG"@fr,
@@ -2993,7 +2993,7 @@ systemmap:QHObqf1JYpt7KGLFS a systemmap:PrivateOrganization ;
         """@it ;
     owl:sameAs zefix:449781 .
 
-systemmap:QQ3N7dTc23t2wzXr2 a systemmap:PrivateOrganization ;
+systemmap:SQ3N7dTc23t2wzXr2 a systemmap:PrivateOrganization ;
     rdfs:label "TSM Treuhand GmbH"@de,
         "TSM Treuhand LLC"@en,
         "TSM Treuhand S. à r. l."@fr,
@@ -3024,9 +3024,9 @@ systemmap:QQ3N7dTc23t2wzXr2 a systemmap:PrivateOrganization ;
         """@it ;
     owl:sameAs zefix:427931 .
 
-systemmap:QWdllcNbPnjdcm7om a systemmap:PrivateOrganization ;
+systemmap:SWdllcNbPnjdcm7om a systemmap:PrivateOrganization ;
     rdfs:label "Agroline"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:1256441 a systemmap:PrivateOrganization ;
     rdfs:label "mooh Genossenschaft"@de .
@@ -3036,36 +3036,36 @@ zefix:2595 a systemmap:PrivateOrganization ;
 
 zefix:330180 a systemmap:PrivateOrganization ;
     rdfs:label "Bison Schweiz AG"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:371013 a systemmap:PrivateOrganization ;
     rdfs:label "Ernst Sutter AG"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:432768 a systemmap:PrivateOrganization ;
     rdfs:label "TRAVECO Transporte AG"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:446080 a systemmap:PrivateOrganization ;
     rdfs:label "frigemo ag"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:505628 a systemmap:PrivateOrganization ;
     rdfs:label "Isagri GmbH"@de .
 
 zefix:7011 a systemmap:PrivateOrganization ;
     rdfs:label "Anicom AG"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:76693 a systemmap:PrivateOrganization ;
     rdfs:label "Halag Chemie AG"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
 zefix:787227 a systemmap:PrivateOrganization ;
     rdfs:label "RAMSEIER Suisse AG"@de ;
-    systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
+    systemmap:ownedBy systemmap:SFAcWHo27bji7sVts .
 
-systemmap:QDqb9NPoB6n3MZf2 a systemmap:SensitivePersonInformation ;
+systemmap:SDqb9NPoB6n3MZf2 a systemmap:SensitivePersonInformation ;
     rdfs:label "Kürzungen von Direktzahlungen"@de,
         "Reductions in direct payments"@en,
         "Réductions des paiements directs"@fr,
@@ -3086,9 +3086,9 @@ systemmap:QDqb9NPoB6n3MZf2 a systemmap:SensitivePersonInformation ;
         Contiene informazioni sulle normative e le procedure in base alle quali i pagamenti diretti alle aziende agricole vengono ridotti.  
         I dati includono criteri, basi di calcolo, periodi interessati e processi amministrativi che possono portare a tali riduzioni.  
         """@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
+    systemmap:containedIn systemmap:SvDlxaJ5YMkuZGH6k .
 
-systemmap:QLvuxq7SeZ6X0GYA a systemmap:SensitivePersonInformation ;
+systemmap:SLvuxq7SeZ6X0GYA a systemmap:SensitivePersonInformation ;
     rdfs:label "Resultate der Milchprüfung"@de,
         "Results of milk testing"@en,
         "Résultats du contrôle du lait"@fr,
@@ -3116,12 +3116,12 @@ systemmap:QLvuxq7SeZ6X0GYA a systemmap:SensitivePersonInformation ;
         Risultati igienicamente insufficienti comportano reclami e, in caso di carenze igieniche prolungate, un divieto ufficiale di consegna del latte.
         I risultati del controllo del latte sono resi disponibili ai soggetti autorizzati tramite la piattaforma dbmilch.ch.
         """@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+    systemmap:containedIn systemmap:SYOd1TkacTh6cr0xP .
 
-systemmap:QfXioR1gkj8eDuTF a systemmap:SensitivePersonInformation ;
+systemmap:SfXioR1gkj8eDuTF a systemmap:SensitivePersonInformation ;
     rdfs:label "Daten über Verwaltungsmassnahmen und strafrechtliche Sanktionen"@de,
         "Data on administrative measures and criminal sanctions"@en,
         "Données sur les mesures administratives et les sanctions pénales"@fr,
         "Dati sulle misure amministrative e sulle sanzioni penali"@it ;
-    systemmap:containedIn systemmap:Q9VcxLSoIIwQjoexY .
+    systemmap:containedIn systemmap:S9VcxLSoIIwQjoexY .
 

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -88,31 +88,6 @@ LwG:art_27 a schema:Legislation ;
 <https://www.fedlex.admin.ch/eli/cc/2016/565> a schema:Legislation ;
     rdfs:label "Verordnung des BLW über die Festlegung von Perioden und Fristen sowie die Freigabe von Zollkontingentsteilmengen für die Einfuhr von frischem Gemüse und frischem Obst (VEAGOG-Freigabeverordnung)"@de .
 
-systemmap:ORG099 a schema:Organization ;
-    rdfs:label "Gemeinsame Anmeldestelle Chemikalien"@de,
-        "Common Notification Authority for Chemicals"@en,
-        "Autorité commune de notification des produits chimiques"@fr,
-        "Autorità comune di notifica delle sostanze chimiche"@it ;
-    schema:member systemmap:ORG096,
-        systemmap:ORG097,
-        systemmap:ORG098 ;
-    rdfs:comment """
-        Die Gemeinsame Anmeldestelle Chemikalien ist die zentrale Anlaufstelle für Chemikalien in der Schweiz.
-        Sie wird vom Bundesamt für Umwelt (BAFU), dem Bundesamt für Gesundheit (BAG) und dem Staatssekretariat für Wirtschaft (SECO) betrieben.
-        """@de,
-        """
-        The Common Notification Authority for Chemicals is the central contact point for chemicals in Switzerland.
-        It is operated by the Federal Office for the Environment (FOEN), the Federal Office of Public Health (FOPH), and the State Secretariat for Economic Affairs (SECO).
-        """@en,
-        """
-        L'Autorité commune de notification des produits chimiques est le point de contact central pour les produits chimiques en Suisse,
-        géré par l'Office fédéral de l'environnement (OFEV), l'Office fédéral de la santé publique (OFSP) et le Secrétariat d'État à l'économie (SECO).
-        """@fr,
-        """
-        L'Autorità comune di notifica delle sostanze chimiche è il punto di contatto centrale per le sostanze chimiche in Svizzera,
-        gestito dall'Ufficio federale dell'ambiente (UFAM), dall'Ufficio federale della sanità pubblica (UFSP) e dalla Segreteria di Stato dell'economia (SECO).
-        """@it .
-
 systemmap:ORG200 a schema:Organization ;
     rdfs:label "Internationale Union zum Schutz von Pflanzenzüchtungen"@de,
         "International Union for the Protection of New Varieties of Plants"@en,
@@ -158,6 +133,31 @@ systemmap:ORG215 a schema:Organization ;
 systemmap:ORG999 a schema:Organization ;
     rdfs:label "Europäische Kommission"@de,
         "European Commission"@en .
+
+systemmap:daccec1f3b64441f98b234bdd8b874dd a schema:Organization ;
+    rdfs:label "Gemeinsame Anmeldestelle Chemikalien"@de,
+        "Common Notification Authority for Chemicals"@en,
+        "Autorité commune de notification des produits chimiques"@fr,
+        "Autorità comune di notifica delle sostanze chimiche"@it ;
+    schema:member systemmap:101f4674d4654b12bc25fa4a3143f32a,
+        systemmap:4e8ca1ec6eeb4786808a5f71486c4bbf,
+        systemmap:5044e9f5dc4347288f5506de98be40af ;
+    rdfs:comment """
+        Die Gemeinsame Anmeldestelle Chemikalien ist die zentrale Anlaufstelle für Chemikalien in der Schweiz.
+        Sie wird vom Bundesamt für Umwelt (BAFU), dem Bundesamt für Gesundheit (BAG) und dem Staatssekretariat für Wirtschaft (SECO) betrieben.
+        """@de,
+        """
+        The Common Notification Authority for Chemicals is the central contact point for chemicals in Switzerland.
+        It is operated by the Federal Office for the Environment (FOEN), the Federal Office of Public Health (FOPH), and the State Secretariat for Economic Affairs (SECO).
+        """@en,
+        """
+        L'Autorité commune de notification des produits chimiques est le point de contact central pour les produits chimiques en Suisse,
+        géré par l'Office fédéral de l'environnement (OFEV), l'Office fédéral de la santé publique (OFSP) et le Secrétariat d'État à l'économie (SECO).
+        """@fr,
+        """
+        L'Autorità comune di notifica delle sostanze chimiche è il punto di contatto centrale per le sostanze chimiche in Svizzera,
+        gestito dall'Ufficio federale dell'ambiente (UFAM), dall'Ufficio federale della sanità pubblica (UFSP) e dalla Segreteria di Stato dell'economia (SECO).
+        """@it .
 
 systemmap:1f309b91ad564bcb99dd6c8c30bbc0dc a schema:SoftwareApplication ;
     rdfs:label "Troup'O Herdenmanager"@de ;
@@ -614,7 +614,7 @@ systemmap:SYS019 a schema:SoftwareApplication ;
         "Create and embed visualizations from any dataset provided by the LINDAS Linked Data Service."@en,
         "Créez et intégrez des visualisations à partir des jeux de données du service LINDAS (Linked Data)."@fr,
         "Crea ed incorpora visualizzazioni partendo dai dataset forniti dal servizio LINDAS (Linked Data)."@it ;
-    systemmap:operatedBy systemmap:ORG096 .
+    systemmap:operatedBy systemmap:4e8ca1ec6eeb4786808a5f71486c4bbf .
 
 systemmap:SYS020 a schema:SoftwareApplication ;
     rdfs:label "Tierverkehrsdatenbank"@de,
@@ -842,7 +842,7 @@ systemmap:SYS028 a schema:SoftwareApplication ;
         "CPR"@en,
         "RPC"@fr,
         "RPC"@it ;
-    systemmap:operatedBy systemmap:ORG099 .
+    systemmap:operatedBy systemmap:daccec1f3b64441f98b234bdd8b874dd .
 
 systemmap:SYS029 a schema:SoftwareApplication ;
     rdfs:label "Marktdaten Analyse- und Reporting-System"@de,
@@ -1366,6 +1366,99 @@ systemmap:ORG340 a systemmap:CantonalVeterinaryService ;
     schema:parentOrganization systemmap:ORG339 ;
     dcat:landingPage <https://www.ag.ch/de/verwaltung/dgs/verbraucherschutz/veterinaerdienst> .
 
+systemmap:101f4674d4654b12bc25fa4a3143f32a a systemmap:FederalOrganization ;
+    rdfs:label "Staatssekretariat für Wirtschaft"@de,
+        "State Secretariat for Economic Affairs"@en,
+        "Secrétariat d'État à l'économie"@fr,
+        "Segretariato di Stato dell'economia"@it ;
+    rdfs:comment """
+        Das Staatssekretariat für Wirtschaft (SECO) ist das Kompetenzzentrum des Bundes für alle Kernfragen der Wirtschaftspolitik.
+        Es fördert nachhaltiges Wirtschaftswachstum und schafft die notwendigen ordnungs- und wirtschaftspolitischen Rahmenbedingungen.
+        Zudem koordiniert es die wirtschaftlichen Beziehungen der Schweiz im In- und Ausland.
+        """@de,
+        """
+        The State Secretariat for Economic Affairs (SECO) is the federal government's competence center for all key issues of economic policy.
+        It promotes sustainable economic growth and establishes the necessary regulatory and economic frameworks.
+        Additionally, it coordinates Switzerland's economic relations both domestically and internationally.
+        """@en,
+        """
+        Le Secrétariat d'État à l'économie (SECO) est le centre de compétence de la Confédération pour toutes les questions clés de la politique économique.
+        Il promeut une croissance économique durable et établit les cadres réglementaires et économiques nécessaires.
+        De plus, il coordonne les relations économiques de la Suisse au niveau national et international.
+        """@fr,
+        """
+        Il Segretariato di Stato dell'economia (SECO) è il centro di competenza della Confederazione per tutte le questioni chiave della politica economica.
+        Promuove una crescita economica sostenibile e crea le necessarie condizioni quadro normative ed economiche.
+        Inoltre, coordina le relazioni economiche della Svizzera a livello nazionale e internazionale.
+        """@it ;
+    owl:sameAs staatskalender:10008856 ;
+    systemmap:abbreviation "SECO"@de,
+        "SECO"@en,
+        "SECO"@fr,
+        "SECO"@it .
+
+systemmap:4e8ca1ec6eeb4786808a5f71486c4bbf a systemmap:FederalOrganization ;
+    rdfs:label "Bundesamt für Umwelt"@de,
+        "Federal Office for the Environment"@en,
+        "Office fédéral de l'environnement"@fr,
+        "Ufficio federale dell'ambiente"@it ;
+    rdfs:comment """
+        Das Bundesamt für Umwelt (BAFU) ist die Umweltfachstelle der Schweiz und gehört zum Eidgenössischen Departement für Umwelt, Verkehr, Energie und Kommunikation (UVEK).
+        Es ist verantwortlich für die nachhaltige Nutzung der natürlichen Ressourcen sowie den Schutz des Menschen vor Naturgefahren und übermässigen Umweltbelastungen.
+        Gegründet 1971, hat das BAFU seinen Hauptsitz in Bern.
+        """@de,
+        """
+        The Federal Office for the Environment (FOEN) is Switzerland's environmental agency and is part of the Federal Department of the Environment, Transport, Energy and Communications (DETEC).
+        It is responsible for the sustainable use of natural resources and the protection of the population from natural hazards and excessive environmental burdens.
+        Founded in 1971, the FOEN is headquartered in Bern.
+        """@en,
+        """
+        L'Office fédéral de l'environnement (OFEV) est l'autorité environnementale de la Suisse et fait partie du Département fédéral de l'environnement, des transports, de l'énergie et de la communication (DETEC).
+        Il est responsable de l'utilisation durable des ressources naturelles ainsi que de la protection de la population contre les dangers naturels et les charges environnementales excessives.
+        Fondé en 1971, l'OFEV a son siège principal à Berne.
+        """@fr,
+        """
+        L'Ufficio federale dell'ambiente (UFAM) è l'agenzia ambientale della Svizzera e fa parte del Dipartimento federale dell'ambiente, dei trasporti, dell'energia e delle comunicazioni (DATEC).
+        È responsabile dell'uso sostenibile delle risorse naturali e della protezione della popolazione dai pericoli naturali e dalle eccessive pressioni ambientali.
+        Fondato nel 1971, l'UFAM ha la sua sede principale a Berna.
+        """@it ;
+    owl:sameAs staatskalender:10008758 ;
+    systemmap:abbreviation "BAFU"@de,
+        "FOEN"@en,
+        "OFEV"@fr,
+        "UFAM"@it .
+
+systemmap:5044e9f5dc4347288f5506de98be40af a systemmap:FederalOrganization ;
+    rdfs:label "Bundesamt für Gesundheit"@de,
+        "Federal Office of Public Health"@en,
+        "Office fédéral de la santé publique"@fr,
+        "Ufficio federale della sanità pubblica"@it ;
+    rdfs:comment """
+        Das Bundesamt für Gesundheit (BAG) ist verantwortlich für die nationale Gesundheitspolitik der Schweiz und fördert die Gesundheit der Bevölkerung in Zusammenarbeit mit den Kantonen.
+        Es setzt sich für ein leistungsfähiges und bezahlbares Gesundheitssystem ein.
+        Zudem vertritt das BAG die Schweiz in internationalen gesundheitspolitischen Belangen.
+        """@de,
+        """
+        The Federal Office of Public Health (FOPH) is responsible for Switzerland's national health policy and promotes public health in collaboration with the cantons.
+        It is committed to an efficient and affordable healthcare system.
+        Additionally, the FOPH represents Switzerland in international public health matters.
+        """@en,
+        """
+        L'Office fédéral de la santé publique (OFSP) est responsable de la politique de santé nationale de la Suisse et promeut la santé de la population en collaboration avec les cantons.
+        Il s'engage pour un système de santé performant et abordable.
+        De plus, l'OFSP représente la Suisse dans les affaires de santé publique internationales.
+        """@fr,
+        """
+        L'Ufficio federale della sanità pubblica (UFSP) è responsabile della politica sanitaria nazionale della Svizzera e promuove la salute della popolazione in collaborazione con i cantoni.
+        Si impegna per un sistema sanitario efficiente e accessibile.
+        Inoltre, l'UFSP rappresenta la Svizzera nelle questioni di salute pubblica a livello internazionale.
+        """@it ;
+    owl:sameAs staatskalender:10008684 ;
+    systemmap:abbreviation "BAG"@de,
+        "FOPH"@en,
+        "OFSP"@fr,
+        "UFSP"@it .
+
 systemmap:ORG001 a systemmap:FederalOrganization ;
     rdfs:label "Bundesamt für Landwirtschaft"@de,
         "Federal Office for Agriculture"@en,
@@ -1794,99 +1887,6 @@ systemmap:ORG041 a systemmap:FederalOrganization ;
         systemmap:INF021,
         systemmap:INF022,
         systemmap:INF023 .
-
-systemmap:ORG096 a systemmap:FederalOrganization ;
-    rdfs:label "Bundesamt für Umwelt"@de,
-        "Federal Office for the Environment"@en,
-        "Office fédéral de l'environnement"@fr,
-        "Ufficio federale dell'ambiente"@it ;
-    rdfs:comment """
-        Das Bundesamt für Umwelt (BAFU) ist die Umweltfachstelle der Schweiz und gehört zum Eidgenössischen Departement für Umwelt, Verkehr, Energie und Kommunikation (UVEK).
-        Es ist verantwortlich für die nachhaltige Nutzung der natürlichen Ressourcen sowie den Schutz des Menschen vor Naturgefahren und übermässigen Umweltbelastungen.
-        Gegründet 1971, hat das BAFU seinen Hauptsitz in Bern.
-        """@de,
-        """
-        The Federal Office for the Environment (FOEN) is Switzerland's environmental agency and is part of the Federal Department of the Environment, Transport, Energy and Communications (DETEC).
-        It is responsible for the sustainable use of natural resources and the protection of the population from natural hazards and excessive environmental burdens.
-        Founded in 1971, the FOEN is headquartered in Bern.
-        """@en,
-        """
-        L'Office fédéral de l'environnement (OFEV) est l'autorité environnementale de la Suisse et fait partie du Département fédéral de l'environnement, des transports, de l'énergie et de la communication (DETEC).
-        Il est responsable de l'utilisation durable des ressources naturelles ainsi que de la protection de la population contre les dangers naturels et les charges environnementales excessives.
-        Fondé en 1971, l'OFEV a son siège principal à Berne.
-        """@fr,
-        """
-        L'Ufficio federale dell'ambiente (UFAM) è l'agenzia ambientale della Svizzera e fa parte del Dipartimento federale dell'ambiente, dei trasporti, dell'energia e delle comunicazioni (DATEC).
-        È responsabile dell'uso sostenibile delle risorse naturali e della protezione della popolazione dai pericoli naturali e dalle eccessive pressioni ambientali.
-        Fondato nel 1971, l'UFAM ha la sua sede principale a Berna.
-        """@it ;
-    owl:sameAs staatskalender:10008758 ;
-    systemmap:abbreviation "BAFU"@de,
-        "FOEN"@en,
-        "OFEV"@fr,
-        "UFAM"@it .
-
-systemmap:ORG097 a systemmap:FederalOrganization ;
-    rdfs:label "Bundesamt für Gesundheit"@de,
-        "Federal Office of Public Health"@en,
-        "Office fédéral de la santé publique"@fr,
-        "Ufficio federale della sanità pubblica"@it ;
-    rdfs:comment """
-        Das Bundesamt für Gesundheit (BAG) ist verantwortlich für die nationale Gesundheitspolitik der Schweiz und fördert die Gesundheit der Bevölkerung in Zusammenarbeit mit den Kantonen.
-        Es setzt sich für ein leistungsfähiges und bezahlbares Gesundheitssystem ein.
-        Zudem vertritt das BAG die Schweiz in internationalen gesundheitspolitischen Belangen.
-        """@de,
-        """
-        The Federal Office of Public Health (FOPH) is responsible for Switzerland's national health policy and promotes public health in collaboration with the cantons.
-        It is committed to an efficient and affordable healthcare system.
-        Additionally, the FOPH represents Switzerland in international public health matters.
-        """@en,
-        """
-        L'Office fédéral de la santé publique (OFSP) est responsable de la politique de santé nationale de la Suisse et promeut la santé de la population en collaboration avec les cantons.
-        Il s'engage pour un système de santé performant et abordable.
-        De plus, l'OFSP représente la Suisse dans les affaires de santé publique internationales.
-        """@fr,
-        """
-        L'Ufficio federale della sanità pubblica (UFSP) è responsabile della politica sanitaria nazionale della Svizzera e promuove la salute della popolazione in collaborazione con i cantoni.
-        Si impegna per un sistema sanitario efficiente e accessibile.
-        Inoltre, l'UFSP rappresenta la Svizzera nelle questioni di salute pubblica a livello internazionale.
-        """@it ;
-    owl:sameAs staatskalender:10008684 ;
-    systemmap:abbreviation "BAG"@de,
-        "FOPH"@en,
-        "OFSP"@fr,
-        "UFSP"@it .
-
-systemmap:ORG098 a systemmap:FederalOrganization ;
-    rdfs:label "Staatssekretariat für Wirtschaft"@de,
-        "State Secretariat for Economic Affairs"@en,
-        "Secrétariat d'État à l'économie"@fr,
-        "Segretariato di Stato dell'economia"@it ;
-    rdfs:comment """
-        Das Staatssekretariat für Wirtschaft (SECO) ist das Kompetenzzentrum des Bundes für alle Kernfragen der Wirtschaftspolitik.
-        Es fördert nachhaltiges Wirtschaftswachstum und schafft die notwendigen ordnungs- und wirtschaftspolitischen Rahmenbedingungen.
-        Zudem koordiniert es die wirtschaftlichen Beziehungen der Schweiz im In- und Ausland.
-        """@de,
-        """
-        The State Secretariat for Economic Affairs (SECO) is the federal government's competence center for all key issues of economic policy.
-        It promotes sustainable economic growth and establishes the necessary regulatory and economic frameworks.
-        Additionally, it coordinates Switzerland's economic relations both domestically and internationally.
-        """@en,
-        """
-        Le Secrétariat d'État à l'économie (SECO) est le centre de compétence de la Confédération pour toutes les questions clés de la politique économique.
-        Il promeut une croissance économique durable et établit les cadres réglementaires et économiques nécessaires.
-        De plus, il coordonne les relations économiques de la Suisse au niveau national et international.
-        """@fr,
-        """
-        Il Segretariato di Stato dell'economia (SECO) è il centro di competenza della Confederazione per tutte le questioni chiave della politica economica.
-        Promuove una crescita economica sostenibile e crea le necessarie condizioni quadro normative ed economiche.
-        Inoltre, coordina le relazioni economiche della Svizzera a livello nazionale e internazionale.
-        """@it ;
-    owl:sameAs staatskalender:10008856 ;
-    systemmap:abbreviation "SECO"@de,
-        "SECO"@en,
-        "SECO"@fr,
-        "SECO"@it .
 
 systemmap:ORG201 a systemmap:FederalOrganization ;
     rdfs:label "Abteilung Wissensgrundlagen"@de,
@@ -2893,6 +2893,10 @@ systemmap:INF043 a systemmap:PersonInformation ;
         "Dati sui controlli e sui risultati dei controlli"@it ;
     systemmap:containedIn systemmap:SYS001 .
 
+systemmap:48aba87e20664cdf98243337e6c6b5c9 a systemmap:PrivateOrganization ;
+    rdfs:label "Agroline"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
 systemmap:ORG100 a systemmap:PrivateOrganization ;
     rdfs:label "TSM Treuhand GmbH"@de,
         "TSM Treuhand LLC"@en,
@@ -2982,9 +2986,9 @@ systemmap:ORG102 a systemmap:PrivateOrganization ;
         La piattaforma integra varie funzioni agronomiche e amministrative e consente una gestione efficiente delle risorse.
         Barto AG collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
         """@it ;
-    systemmap:ownedBy systemmap:ORG103 .
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
 
-systemmap:ORG103 a systemmap:PrivateOrganization ;
+systemmap:dd44a374e6ab40f4b692ffefdae72165 a systemmap:PrivateOrganization ;
     rdfs:label "Fenaco Genossenschaft"@de,
         "Fenaco Cooperative"@en,
         "Coopérative Fenaco"@fr,
@@ -3012,13 +3016,45 @@ systemmap:ORG103 a systemmap:PrivateOrganization ;
         Opera nei settori del commercio agricolo, della produzione alimentare, del commercio al dettaglio e dell'energia.
         Fenaco possiede marchi come Landi, Volg, Agrola e vari produttori alimentari.
         La cooperativa è di proprietà degli agricoltori svizzeri e ha la sua sede principale a Berna.
-        """@it .
+        """@it ;
+    owl:sameAs zefix:328631 .
 
-zefix:1256441 a systemmap:PrivateOrganization .
+zefix:1256441 a systemmap:PrivateOrganization ;
+    rdfs:label "mooh Genossenschaft"@de .
 
-zefix:2595 a systemmap:PrivateOrganization .
+zefix:2595 a systemmap:PrivateOrganization ;
+    rdfs:label "ASF Tiervermarktung AG"@de .
 
-zefix:505628 a systemmap:PrivateOrganization .
+zefix:330180 a systemmap:PrivateOrganization ;
+    rdfs:label "Bison Schweiz AG"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
+zefix:371013 a systemmap:PrivateOrganization ;
+    rdfs:label "Ernst Sutter AG"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
+zefix:432768 a systemmap:PrivateOrganization ;
+    rdfs:label "TRAVECO Transporte AG"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
+zefix:446080 a systemmap:PrivateOrganization ;
+    rdfs:label "frigemo ag"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
+zefix:505628 a systemmap:PrivateOrganization ;
+    rdfs:label "Isagri GmbH"@de .
+
+zefix:7011 a systemmap:PrivateOrganization ;
+    rdfs:label "Anicom AG"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
+zefix:76693 a systemmap:PrivateOrganization ;
+    rdfs:label "Halag Chemie AG"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
+
+zefix:787227 a systemmap:PrivateOrganization ;
+    rdfs:label "RAMSEIER Suisse AG"@de ;
+    systemmap:ownedBy systemmap:dd44a374e6ab40f4b692ffefdae72165 .
 
 systemmap:INF017 a systemmap:SensitivePersonInformation ;
     rdfs:label "Kürzungen von Direktzahlungen"@de,

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -5,6 +5,7 @@
 @prefix schema: <http://schema.org/> .
 @prefix staatskalender: <https://register.ld.admin.ch/staatskalender/organization/> .
 @prefix systemmap: <https://agriculture.ld.admin.ch/system-map/> .
+@prefix zefix: <https://register.ld.admin.ch/zefix/company/> .
 
 <https://www.fedlex.admin.ch/eli/cc/1986/926_926_926> a schema:Legislation ;
     rdfs:label "Bundesgesetz über die landwirtschaftliche Pacht"@de .
@@ -157,6 +158,10 @@ systemmap:ORG215 a schema:Organization ;
 systemmap:ORG999 a schema:Organization ;
     rdfs:label "Europäische Kommission"@de,
         "European Commission"@en .
+
+systemmap:1f309b91ad564bcb99dd6c8c30bbc0dc a schema:SoftwareApplication ;
+    rdfs:label "Troup'O Herdenmanager"@de ;
+    systemmap:operatedBy zefix:505628 .
 
 systemmap:SYS001 a schema:SoftwareApplication ;
     rdfs:label "Acontrol"@de,
@@ -981,6 +986,10 @@ systemmap:SYS042 a schema:SoftwareApplication ;
         "Uno strumento di visualizzazione delle informazioni sui sistemi IT, i dati in essi contenuti e le organizzazioni che li gestiscono nel settore agroalimentare svizzero."@it ;
     dcat:landingPage <https://blw-ofag-ufag.github.io/system-map/> ;
     systemmap:operatedBy systemmap:ORG011 .
+
+systemmap:f4c51499ef7f40e6ac4ec446f508a9bb a schema:SoftwareApplication ;
+    rdfs:label "Mooh Intranet"@de ;
+    systemmap:operatedBy zefix:1256441 .
 
 systemmap:ORG300 a systemmap:CantonalOrganization ;
     rdfs:label "Kanton Aargau"@de,
@@ -2912,7 +2921,8 @@ systemmap:ORG100 a systemmap:PrivateOrganization ;
         TSM sta per Fiduciario, Statistica e Management. L'attività principale di TSM è la gestione del database dbmilch.ch.
         Inoltre, vengono svolti altri incarichi nei settori della fiduciaria, della gestione dei fondi, delle statistiche e dei controlli all'esportazione.
         Il principale committente di TSM è l'Ufficio federale dell'agricoltura (UFAG).
-        """@it .
+        """@it ;
+    owl:sameAs zefix:427931 .
 
 systemmap:ORG101 a systemmap:PrivateOrganization ;
     rdfs:label "Identitas AG"@de,
@@ -2940,7 +2950,8 @@ systemmap:ORG101 a systemmap:PrivateOrganization ;
         Fornisce soluzioni per la tracciabilità degli animali, la salute animale e la sicurezza alimentare.
         In qualità di fornitore di servizi IT per la Confederazione, i cantoni e gli attori privati, Identitas AG offre servizi digitali per la registrazione, l'elaborazione e l'analisi dei dati sugli animali e sulle aziende agricole.
         L'azienda ha sede a Berna.
-        """@it .
+        """@it ;
+    owl:sameAs zefix:449781 .
 
 systemmap:ORG102 a systemmap:PrivateOrganization ;
     rdfs:label "Barto AG"@de,
@@ -3002,6 +3013,12 @@ systemmap:ORG103 a systemmap:PrivateOrganization ;
         Fenaco possiede marchi come Landi, Volg, Agrola e vari produttori alimentari.
         La cooperativa è di proprietà degli agricoltori svizzeri e ha la sua sede principale a Berna.
         """@it .
+
+zefix:1256441 a systemmap:PrivateOrganization .
+
+zefix:2595 a systemmap:PrivateOrganization .
+
+zefix:505628 a systemmap:PrivateOrganization .
 
 systemmap:INF017 a systemmap:SensitivePersonInformation ;
     rdfs:label "Kürzungen von Direktzahlungen"@de,

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -159,6 +159,31 @@ systemmap:QhM5kJNFhO8vOAEdK a schema:Organization ;
     rdfs:label "Europäische Kommission"@de,
         "European Commission"@en .
 
+systemmap:Q4gV9U3dvmENkSnj a schema:SoftwareApplication ;
+    rdfs:label "Informationssystem für meldepflichtige Krankheiten"@de,
+        "Information system for cases of notifiable diseases"@en,
+        "Système d'information pour les maladies à déclaration obligatoire"@fr,
+        "Sistema informativo per le malattie soggette a notifica"@it ;
+    rdfs:comment """
+        Dashboard zur Visualisierung und Filterung verknüpfter Tierseuchendaten, die vom Bundesamt für Lebensmittelsicherheit und Veterinärwesen veröffentlicht werden.
+        """@de,
+        """
+        Dashboard for the visualization and filtering of linked animal diseases data published by the Swiss Federal Food Safety and Veterinary Office.
+        """@en,
+        """
+        Tableau de bord pour la visualisation et le filtrage des données liées aux maladies animales publiées par l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires.
+        """@fr,
+        """
+        Dashboard per la visualizzazione e il filtraggio dei dati sulle malattie animali pubblicati dall'Ufficio federale della sicurezza alimentare e di veterinaria.
+        """@it ;
+    rdfs:seeAlso <https://github.com/digital-sustainability/blv-infosm> ;
+    dcat:landingPage <https://www.dashboard.blv.admin.ch/> ;
+    systemmap:abbreviation "InfoSM"@de,
+        "InfoSM"@en,
+        "InfoSM"@fr,
+        "InfoSM"@it ;
+    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
+
 systemmap:Q6J4iyI6nMI2RCXSY a schema:SoftwareApplication ;
     rdfs:label "CePa"@de,
         "CePa"@en,
@@ -169,6 +194,57 @@ systemmap:Q6J4iyI6nMI2RCXSY a schema:SoftwareApplication ;
         "CePa est une application informatique pour la gestion numérique des procédures et de la correspondance dans le cadre du système de passeport phytosanitaire ainsi que de la certification officielle du matériel de multiplication. Elle optimise les processus de certification et garantit le respect des réglementations phytosanitaires. De cette manière, elle soutient la traçabilité et le contrôle de la qualité du matériel végétal."@fr,
         "CePa è un'applicazione IT per la gestione digitale delle procedure e della corrispondenza nell'ambito del sistema del passaporto delle piante e della certificazione ufficiale del materiale di propagazione. Ottimizza i processi di certificazione e garantisce il rispetto delle normative fitosanitarie. In questo modo, supporta la tracciabilità e il controllo della qualità del materiale vegetale."@it ;
     systemmap:operatedBy systemmap:QFL2DYxeNnVaFsv64 .
+
+systemmap:Q7u1Bh6qfXUbSDkv a schema:SoftwareApplication ;
+    rdfs:label "e-Deklaration"@de,
+        "e-declaration"@en,
+        "e-déclaration"@fr,
+        "e-dichiarazione"@it ;
+    rdfs:comment "e-dec ist das elektronische Zollanmeldesystem der Schweiz, das Unternehmen ermöglicht, Waren für Import, Export und Transit elektronisch zu deklarieren. Dank seines modularen Aufbaus optimiert es die Zollprozesse, was zu Kosteneinsparungen und höherer Effizienz führt. Besonders hervorzuheben ist, dass e-dec mehrere Kommunikationsstandards unterstützt und jede Zollanmeldung bis zu 99'999 Tarifpositionen enthalten kann."@de,
+        "e-dec is Switzerland's electronic customs declaration system that enables companies to declare goods for import, export, and transit electronically. Designed with a modular structure, it streamlines customs processes, leading to cost savings and increased efficiency. Notably, e-dec supports multiple communication standards and allows each customs declaration to include up to 99'999 tariff headings."@en,
+        "e-dec est le système électronique de déclaration en douane de la Suisse, permettant aux entreprises de déclarer électroniquement les marchandises à l'importation, à l'exportation et en transit. Conçu avec une structure modulaire, il optimise les processus douaniers, entraînant des économies de coûts et une efficacité accrue. Notamment, e-dec prend en charge plusieurs normes de communication et permet à chaque déclaration en douane d'inclure jusqu'à 99'999 positions tarifaires."@fr,
+        "e-dec è il sistema elettronico di dichiarazione doganale della Svizzera che consente alle aziende di dichiarare elettronicamente le merci per l'importazione, l'esportazione e il transito. Progettato con una struttura modulare, ottimizza i processi doganali, portando a risparmi sui costi e a una maggiore efficienza. In particolare, e-dec supporta diversi standard di comunicazione e consente a ogni dichiarazione doganale di includere fino a 99'999 voci tariffarie."@it ;
+    systemmap:abbreviation "e-dec"@de,
+        "e-dec"@en,
+        "e-dec"@fr,
+        "e-dec"@it ;
+    systemmap:operatedBy systemmap:QFKPRpdGa5UISiJlx .
+
+systemmap:Q9SbhGAwWjtvcRIZ a schema:SoftwareApplication ;
+    rdfs:label "Geografisches Informationssystem"@de,
+        "Geographic Information System"@en,
+        "Système d'information géographique"@fr,
+        "Sistema informativo geografico"@it ;
+    rdfs:comment """
+        Viele Arbeiten und Projekte des BLW haben einen Raumbezug.
+        Das GIS dient der Aufbereitung, Analyse, Auswertung und Darstellung raumbezogener landwirtschaftlicher Daten.
+        Das GIS dient im BLW insbesondere der Nachführung der landwirtschaftlichen Zonengrenzen und Hanglagen.
+        Zudem werden verschiedene andere thematische raumbezogene Fragestellungen im Zusammenhang mit dem Vollzug und der Weiterentwicklung der Agrarpolitik mit dem GIS bearbeitet.
+        """@de,
+        """
+        Many tasks and projects of the FOAG have a spatial reference.
+        The GIS is used for processing, analyzing, evaluating, and visualizing spatial agricultural data.
+        In the FOAG, the GIS is particularly used for updating agricultural zone boundaries and slope areas.
+        In addition, various other thematic spatial issues related to the implementation and further development of agricultural policy are addressed with the GIS.
+        """@en,
+        """
+        De nombreuses tâches et projets de l'OFAG ont une référence spatiale.
+        Le SIG sert à traiter, analyser, évaluer et visualiser les données agricoles spatiales.
+        À l'OFAG, le SIG est notamment utilisé pour la mise à jour des limites des zones agricoles et des pentes.
+        De plus, diverses autres questions spatiales thématiques en lien avec l'exécution et le développement de la politique agricole sont traitées avec le SIG.
+        """@fr,
+        """
+        Molti compiti e progetti dell'UFAG hanno un riferimento spaziale.
+        Il GIS viene utilizzato per l'elaborazione, l'analisi, la valutazione e la visualizzazione dei dati agricoli spaziali.
+        All'UFAG, il GIS è utilizzato in particolare per l'aggiornamento dei confini delle zone agricole e delle aree in pendenza.
+        Inoltre, con il GIS vengono affrontate diverse altre questioni tematiche spaziali legate all'attuazione e allo sviluppo della politica agricola.
+        """@it ;
+    systemmap:abbreviation "GIS-BLW"@de,
+        "GIS-BLW"@en,
+        "GIS-BLW"@fr,
+        "GIS-BLW"@it ;
+    systemmap:hasLegalBasis LwG:art_165_e ;
+    systemmap:operatedBy systemmap:QE8y4MuFWW5BKqK92 .
 
 systemmap:Q9VcxLSoIIwQjoexY a schema:SoftwareApplication ;
     rdfs:label "Acontrol"@de,
@@ -244,6 +320,35 @@ systemmap:QGdyOoksCnRRZwi2Q a schema:SoftwareApplication ;
         "Agate è un portale online che consente l'accesso a diverse applicazioni agricole con un solo login. Facilita lo scambio di dati nel settore agricolo e alimentare, aumentando così la comodità per gli utenti. Questo punto di accesso centralizzato semplifica i processi amministrativi per tutte le parti interessate."@it ;
     systemmap:operatedBy systemmap:QQbNLiw8h9MnSXuyo .
 
+systemmap:QHEaRYIgvZ3xrDLo a schema:SoftwareApplication ;
+    rdfs:label "Produkteregister Chemikalien"@de,
+        "Chemical Products Register"@en,
+        "Registre des produits chimiques"@fr,
+        "Registro dei prodotti chimici"@it ;
+    rdfs:comment """
+        Das Produkteregister Chemikalien (RPC) ist die zentrale Datenbank des Bundes für gefährliche chemische Stoffe und Gemische.
+        Es ermöglicht Unternehmen, neue Produkte zu melden oder Zulassungsanträge zu stellen sowie bereits registrierte Produkte zu aktualisieren.
+        Zudem dient es als öffentlich zugängliche Rechercheplattform für gemeldete, angemeldete und zugelassene Chemikalien.
+        """@de,
+        """
+        The Chemical Products Register (RPC) is the federal central database for hazardous chemical substances and mixtures.
+        It enables companies to report new products, submit approval applications, and update already registered products.
+        Additionally, it serves as a publicly accessible research platform for reported, registered, and approved chemicals.
+        """@en,
+        """Le Registre des produits chimiques (RPC) est la base de données centrale fédérale pour les substances chimiques dangereuses et les mélanges.
+        Il permet aux entreprises de déclarer de nouveaux produits, de soumettre des demandes d'approbation et de mettre à jour les produits déjà enregistrés.
+        De plus, il sert de plateforme de recherche accessible au public pour les produits chimiques déclarés, enregistrés et approuvés.
+        """@fr,
+        """Il Registro dei prodotti chimici (RPC) è la banca dati centrale federale per le sostanze chimiche pericolose e le miscele.
+        Consente alle aziende di segnalare nuovi prodotti, presentare domande di approvazione e aggiornare i prodotti già registrati.
+        Inoltre, funge da piattaforma di ricerca accessibile al pubblico per i prodotti chimici segnalati, registrati e approvati.
+        """@it ;
+    systemmap:abbreviation "RPC"@de,
+        "CPR"@en,
+        "RPC"@fr,
+        "RPC"@it ;
+    systemmap:operatedBy systemmap:QGayLcAMcywbigd3M .
+
 systemmap:QHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
     rdfs:label "LINDAS"@de,
         "LINDAS"@en,
@@ -254,6 +359,50 @@ systemmap:QHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
         "Avec les services Linked Data LINDAS, les administrations publiques peuvent publier leurs données sous forme de graphe de connaissances et les rendre accessibles via https://lindas.admin.ch."@fr,
         "Con i Linked Data Services LINDAS, le pubbliche amministrazioni possono pubblicare i loro dati sotto forma di grafi di conoscenza e renderli accessibili attraverso https://lindas.admin.ch."@it ;
     systemmap:operatedBy systemmap:Q6VSaFePQaMGqU8vD .
+
+systemmap:QHyBeGX0LsQwjJ6Z a schema:SoftwareApplication ;
+    rdfs:label "Betriebs- und Unternehmensregister"@de,
+        "Register of Enterprises and Establishments"@en,
+        "Registre des entreprises et des établissements"@fr,
+        "Registro delle imprese e degli stabilimenti"@it ;
+    rdfs:comment """
+        Das Betriebs- und Unternehmensregister (BUR) umfasst alle Unternehmen und Betriebe des privaten und öffentlichen Rechts, die in der Schweiz domiziliert sind und eine wirtschaftliche Tätigkeit ausüben.
+        Das BUR dient dem BFS als Adressregister für die statistischen Erhebungen bei Unternehmen und Arbeitsstätten.
+        Auch andere Ämter der Bundesverwaltung und zahlreiche Kantone verwenden das BUR zu statistischen oder administrativen Zwecken.
+        """@de,
+        """
+        The Register of Enterprises and Establishments (BUR) includes all private and public legal entities domiciled in Switzerland that engage in economic activity.
+        The BUR serves the FSO as an address register for statistical surveys of businesses and workplaces.
+        Other federal administration offices and numerous cantons also use the BUR for statistical or administrative purposes.
+        """@en,
+        """
+        Le Registre des entreprises et des établissements (REE) recense toutes les entreprises et établissements de droit privé et public domiciliés en Suisse et exerçant une activité économique.
+        Le REE sert de registre d'adresses pour les enquêtes statistiques menées par l'OFS auprès des entreprises et des lieux de travail.
+        D'autres offices de l'administration fédérale ainsi que de nombreux cantons utilisent également le REE à des fins statistiques ou administratives.
+        """@fr,
+        """
+        Il Registro delle imprese e degli stabilimenti (BUR) comprende tutte le imprese e gli stabilimenti di diritto privato e pubblico domiciliati in Svizzera che svolgono un'attività economica.
+        Il BUR serve all'UST come registro degli indirizzi per le rilevazioni statistiche su imprese e luoghi di lavoro.
+        Anche altri uffici dell'amministrazione federale e numerosi cantoni utilizzano il BUR a fini statistici o amministrativi.
+        """@it ;
+    systemmap:abbreviation "BUR"@de,
+        "BUR"@en,
+        "REE"@fr,
+        "BUR"@it ;
+    systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/1993/2253_2253_2253> ;
+    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
+
+systemmap:QLxeXHOfmC6DkBGl a schema:SoftwareApplication ;
+    rdfs:label "Zentrale Auswertung von Agrarumweltindikatoren"@de ;
+    rdfs:comment """
+        Die 'ZA-AUI: Betriebsrückmeldung' ermöglicht den Teilnehmenden am Projekt ZA-AUI die berechneten Agrarumweltindikatoren (AUI) ihres Betriebs online abzurufen, für welche sie jährlich Daten an Agroscope liefern.
+        Die eigenen Betriebsergebnisse können mit den AUI-Ergebnissen desselben Betriebstyps aus dem ZA-AUI-Betriebsnetz verglichen werden.
+        """@de ;
+    dcat:landingPage <https://apps.agroscope.info/sp/za-aui/2/app/datenreihe>,
+        <https://www.agrarumweltindikatoren.ch>,
+        <https://www.za-aui.ch> ;
+    systemmap:abbreviation "ZA-AUI"@de ;
+    systemmap:operatedBy staatskalender:20050530 .
 
 systemmap:QMjqlEoVCR9wpTyN1 a schema:SoftwareApplication ;
     rdfs:label "Acorda"@de,
@@ -284,6 +433,24 @@ systemmap:QMjqlEoVCR9wpTyN1 a schema:SoftwareApplication ;
         systemmap:QTBfdlLfF2K2AJypD,
         systemmap:QTg0zUHrhEWXotIau,
         systemmap:Qqo5ZJtzXw1gg3RYC .
+
+systemmap:QNQSYR7J0IEZpyFT a schema:SoftwareApplication ;
+    rdfs:label "Auswertung/Analyse, Lebensmittelsicherheit, Veterinärwesen, Public Health"@de ;
+    rdfs:comment """
+        ALVPH ist das Datawarehouse des Veterinärdienstes Schweiz.
+        Es dient als zentrale Datenplattform, die flexible Abfragen, Standarberichterstattung und statistische Auswertungen über mehrere Datenquellen ermöglicht.
+        Ausserdem verfügt ALVPH über viele graphische Funktionen, die eine attraktive Präsentation der Daten erlauben.
+        """@de ;
+    systemmap:abbreviation "ALVPH"@de ;
+    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
+
+systemmap:QOL6kHAvPFNIuM9E a schema:SoftwareApplication ;
+    rdfs:label "Traces"@de ;
+    rdfs:comment """
+        Alle Personen und Firmen, die am Import- oder Exportprozess für den internationalen Handel von Tieren, Waren tierischen Ursprungs und gewissen Produkten nicht-tierischen Ursprungs beteiligt sind, müssen sich in Traces registrieren lassen.
+        Es handelt sich um ein eine Webanwendung der Europäischen Union und unterstützt den grenzüberschreitenden Verkehr von Tieren, Lebensmitteln und tierischen Nebenprodukten.
+        """@de ;
+    systemmap:operatedBy systemmap:QhM5kJNFhO8vOAEdK .
 
 systemmap:QPWOFHR512FuAc25b a schema:SoftwareApplication ;
     rdfs:label "Gesamtlösung EDV Landwirtschaft & Natur"@de,
@@ -319,6 +486,18 @@ systemmap:QPWOFHR512FuAc25b a schema:SoftwareApplication ;
         systemmap:Qp5pkmAETRpXrudck,
         systemmap:QyTRdNaA9EH12lhiE .
 
+systemmap:QQfl1MHnNpsAj3WP a schema:SoftwareApplication ;
+    rdfs:label "DigiAgriFoodCH Systemlandkarte"@de,
+        "DigiAgriFoodCH System Map"@en,
+        "Carte du système DigiAgriFoodCH"@fr,
+        "Mappa del sistema DigiAgriFoodCH"@it ;
+    rdfs:comment "Ein Visualisierungstool für Informationen über IT-Systeme, die darin enthaltenen Daten und deren betreibende Organisationen im Schweizer Agrar- und Ernährungssektor."@de,
+        "A visualization tool for information about IT systems, the data those contain and their operating organizations in the Swiss agri-food sector."@en,
+        "Un outil de visualisation des informations sur les systèmes informatiques, les données qu'ils contiennent et les organisations qui les exploitent dans le secteur agroalimentaire suisse."@fr,
+        "Uno strumento di visualizzazione delle informazioni sui sistemi IT, i dati in essi contenuti e le organizzazioni che li gestiscono nel settore agroalimentare svizzero."@it ;
+    dcat:landingPage <https://blw-ofag-ufag.github.io/system-map/> ;
+    systemmap:operatedBy systemmap:QFAwQAwxBcNnaURgO .
+
 systemmap:QU88cJmqj8nBRl2KZ a schema:SoftwareApplication ;
     rdfs:label "Tierverkehrsdatenbank"@de,
         "Animal Traffic Database"@en,
@@ -349,6 +528,25 @@ systemmap:QU88cJmqj8nBRl2KZ a schema:SoftwareApplication ;
         "BDTA"@fr,
         "BDTA"@it ;
     systemmap:operatedBy systemmap:QHObqf1JYpt7KGLFS .
+
+systemmap:QXcby9KwakDGhBdP a schema:SoftwareApplication ;
+    rdfs:label "ACmobile"@de,
+        "ACmobile"@en,
+        "ACmobile"@fr,
+        "ACmobile"@it ;
+    rdfs:comment """
+        ACmobile ist eine plattformunabhängige, mobile Lösung für die elektronische Erfassung von Kontrollergebnissen und Massnahmen.
+        """@de,
+        """
+        ACmobile is a platform-independent mobile solution for the electronic recording of inspection results and measures.
+        """@en,
+        """
+        ACmobile est une solution mobile indépendante de la plateforme pour l'enregistrement électronique des résultats de contrôle et des mesures.
+        """@fr,
+        """
+        ACmobile è una soluzione mobile indipendente dalla piattaforma per la registrazione elettronica dei risultati delle ispezioni e delle misure.
+        """@it ;
+    systemmap:operatedBy systemmap:QmI5VgF2mECWT74i2 .
 
 systemmap:QYOd1TkacTh6cr0xP a schema:SoftwareApplication ;
     rdfs:label "Datenbank Milch"@de,
@@ -423,6 +621,29 @@ systemmap:QZ9LRAuSt2EOvBpqY a schema:SoftwareApplication ;
         systemmap:QVpDMEiTfIVQsNzT8,
         systemmap:QoVAiCrMPYG2LJxsA .
 
+systemmap:Qc6kZqxTyS0gFGCY a schema:SoftwareApplication ;
+    rdfs:label "Marktdaten Analyse- und Reporting-System"@de,
+        "Market Data Analysis and Reporting System"@en,
+        "Système d'analyse et de reporting des données de marché"@fr,
+        "Sistema di analisi e reportistica dei dati di mercato"@it ;
+    rdfs:comment """
+        Im Marktdaten Analyse- und Reporting-System (MARS III) werden Preis- und andere wichtige Agrarmarktdaten gesammelt, aggregiert, berechnet, analysiert und für Berichte aufbereitet.
+        """@de,
+        """
+        The Market Data Analysis and Reporting System (MARS III) collects, aggregates, calculates, analyzes, and prepares price and other important agricultural market data for reports.
+        """@en,
+        """
+        Le Système d'analyse et de reporting des données de marché (MARS III) collecte, agrège, calcule, analyse et prépare les données de prix et autres données importantes du marché agricole pour des rapports.
+        """@fr,
+        """
+        Il Sistema di analisi e reportistica dei dati di mercato (MARS III) raccoglie, aggrega, calcola, analizza e prepara i dati sui prezzi e altri dati importanti del mercato agricolo per i rapporti.
+        """@it ;
+    systemmap:abbreviation "MARS III"@de,
+        "MARS III"@en,
+        "MARS III"@fr,
+        "MARS III"@it ;
+    systemmap:operatedBy systemmap:QaVyVVsIDkiDMtQq4 .
+
 systemmap:QeJ36zAhO3AJJix8t a schema:SoftwareApplication ;
     rdfs:label "Nationale Informationssystem für die Pflanzengenetischen Ressourcen für Ernährung und Landwirtschaft"@de,
         "National Information System for Plant Genetic Resources for Food and Agriculture"@en,
@@ -446,6 +667,29 @@ systemmap:Qfv81BPRW0TSnKhGg a schema:SoftwareApplication ;
         Dank RFID-Kompatibilität und einer intuitiven Benutzeroberfläche erleichtert Troup'O das Herdenmanagement und steigert die Betriebseffizienz.
         """@de ;
     systemmap:operatedBy zefix:505628 .
+
+systemmap:Qfwx1dZMcl5OXtzb a schema:SoftwareApplication ;
+    rdfs:label "Apinella"@de ;
+    rdfs:comment """
+        Software insbesondere für die Früherkennungsprogramm des kleiner Beutenkäfer bei Bienen.
+        """@de ;
+    dcat:landingPage <https://www.apinella.ch/> ;
+    systemmap:operatedBy systemmap:Q3Rf79NI3Pm1rfOlN .
+
+systemmap:QgjZ0efLbuCR2HvN a schema:SoftwareApplication ;
+    rdfs:label "Pflanzensorten-Datenbank"@de,
+        "Plant Variety Database"@en,
+        "Base de données des variétés de plantes"@fr,
+        "Database delle varietà vegetali"@it ;
+    rdfs:comment "Die PLUTO-Datenbank enthält Informationen über Pflanzenarten und -sorten von UPOV-Mitgliedern sowie der Organisation für wirtschaftliche Zusammenarbeit und Entwicklung (OECD). Die PLUTO-Datenbank bietet ein Suchinstrument für Sortenbezeichnungen, um die Unterscheidbarkeit neuer Sorten sicherzustellen."@de,
+        "The PLUTO database contains information on plant species and varieties from UPOV members as well as the Organisation for Economic Co-operation and Development (OECD). The PLUTO database provides a search tool for variety denominations to ensure the distinctness of new varieties."@en,
+        "La base de données PLUTO contient des informations sur les espèces et variétés de plantes des membres de l'UPOV ainsi que de l'Organisation de coopération et de développement économiques (OCDE). La base de données PLUTO offre un outil de recherche pour les dénominations variétales afin d'assurer la distinction des nouvelles variétés."@fr,
+        "Il database PLUTO contiene informazioni sulle specie e varietà vegetali dei membri dell'UPOV e dell'Organizzazione per la cooperazione e lo sviluppo economico (OCSE). Il database PLUTO fornisce uno strumento di ricerca per le denominazioni varietali al fine di garantire la distinzione delle nuove varietà."@it ;
+    systemmap:abbreviation "PLUTO"@de,
+        "PLUTO"@en,
+        "PLUTO"@fr,
+        "PLUTO"@it ;
+    systemmap:operatedBy systemmap:QBLH2G6TSKaqhqk4n .
 
 systemmap:QhZO092di7cBnOm7F a schema:SoftwareApplication ;
     rdfs:label "Business-Intelligence-System"@de,
@@ -515,6 +759,33 @@ systemmap:QjCVTMrYaOTygNcqF a schema:SoftwareApplication ;
     systemmap:hasLegalBasis LwG:art_165_f,
         LwG:art_165_f_bis ;
     systemmap:operatedBy systemmap:QyfZhzeyT1CqJU0BP .
+
+systemmap:QlTSOXsBC2LN7Qkp a schema:SoftwareApplication ;
+    rdfs:label "Barto"@de,
+        "Barto"@en,
+        "Barto"@fr,
+        "Barto"@it ;
+    rdfs:comment """
+        Barto ist eine digitale Plattform für die Landwirtschaft, die eine effiziente Betriebsführung, Dokumentation und Analyse von Betriebsdaten ermöglicht.
+        Sie integriert verschiedene agronomische und administrative Funktionen und bietet Landwirtinnen und Landwirten eine zentrale Lösung für die Verwaltung ihres Betriebs.
+        Barto wird von der Barto AG betrieben und arbeitet mit Partnern aus der Agrarbranche zusammen, um innovative digitale Lösungen bereitzustellen.
+        """@de,
+        """
+        Barto is a digital platform for agriculture that enables efficient farm management, documentation, and analysis of farm data.
+        It integrates various agronomic and administrative functions and provides farmers with a central solution for managing their operations.
+        Barto is operated by Barto AG and collaborates with partners from the agricultural sector to provide innovative digital solutions.
+        """@en,
+        """
+        Barto est une plateforme numérique pour l'agriculture qui permet une gestion efficace des exploitations, la documentation et l'analyse des données agricoles.
+        Elle intègre diverses fonctions agronomiques et administratives et offre aux agriculteurs une solution centrale pour la gestion de leur exploitation.
+        Barto est exploitée par Barto AG et collabore avec des partenaires du secteur agricole pour fournir des solutions numériques innovantes.
+        """@fr,
+        """
+        Barto è una piattaforma digitale per l'agricoltura che consente una gestione aziendale efficiente, la documentazione e l'analisi dei dati aziendali.
+        Integra diverse funzioni agronomiche e amministrative e offre agli agricoltori una soluzione centrale per la gestione della loro azienda.
+        Barto è gestita da Barto AG e collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
+        """@it ;
+    systemmap:operatedBy systemmap:QDetpcQhSMo4IAeAb .
 
 systemmap:QlfheulBjlQDwuaIM a schema:SoftwareApplication ;
     rdfs:label "HODUFLU"@de,
@@ -648,6 +919,44 @@ systemmap:QpR2aDraNmiUXz55J a schema:SoftwareApplication ;
         """@it ;
     systemmap:operatedBy systemmap:QG5yBV3kE5E5NMM7j .
 
+systemmap:QtGKp6nS3OwEm4I0 a schema:SoftwareApplication ;
+    rdfs:label "eMapis"@de ;
+    rdfs:comment """
+        eMapis wurde entwickelt, um die veraltete MAPIS-Applikation abzulösen und die digitale Verwaltung von Finanzhilfegesuchen, wie Bundesbeiträge und zinslose Darlehen, zu ermöglichen.
+        Das System zentralisiert die Erfassung und Verwaltung von Daten sowie Dokumenten, wodurch Doppelerfassungen vermieden werden.
+        Mit automatisierten Workflows, einer zentralen Benutzerverwaltung und der Integration von GIS-Daten (sowie zukünftig Betriebsdaten) verbessert eMapis die Transparenz und Effizienz in der Bearbeitung der Finanzhilfefälle.
+        """@de ;
+    systemmap:operatedBy systemmap:QG8fSveeGZNcYzoUN .
+
+systemmap:QuEtT7joC8HXVSfF a schema:SoftwareApplication ;
+    rdfs:label "UID-Register"@de,
+        "UID Register"@en,
+        "Registre UID"@fr,
+        "Registro UID"@it ;
+    rdfs:comment """
+        Das UID-Register ist eine zentrale Datenbank des Bundesamts für Statistik (BFS), die der eindeutigen Identifikation von Unternehmen in der Schweiz dient.
+        Jedes in der Schweiz aktive Unternehmen erhält eine einheitliche Unternehmens-Identifikationsnummer (UID), die administrative Abläufe vereinfacht und die Zusammenarbeit zwischen Behörden effizienter gestaltet.
+        Die im UID-Register enthaltenen Daten beschränken sich auf das für die Identifikation notwendige Minimum.
+        """@de,
+        """
+        The UID Register is a central database of the Federal Statistical Office (FSO) that serves the unique identification of companies in Switzerland.
+        Every company active in Switzerland receives a unique Business Identification Number (UID), which simplifies administrative processes and enhances collaboration between authorities.
+        The data contained in the UID Register is limited to the minimum necessary for identification.
+        """@en,
+        """
+        Le registre UID est une base de données centrale de l'Office fédéral de la statistique (OFS) qui sert à l'identification unique des entreprises en Suisse.
+        Chaque entreprise active en Suisse reçoit un numéro d'identification des entreprises (UID) unique, ce qui simplifie les processus administratifs et améliore la collaboration entre les autorités.
+        Les données contenues dans le registre UID se limitent au minimum nécessaire pour l'identification.
+        """@fr,
+        """
+        Il registro UID è una banca dati centrale dell'Ufficio federale di statistica (UST) che serve all'identificazione univoca delle imprese in Svizzera.
+        Ogni impresa attiva in Svizzera riceve un numero d'identificazione aziendale (UID) unico, che semplifica i processi amministrativi e migliora la collaborazione tra le autorità.
+        I dati contenuti nel registro UID sono limitati al minimo necessario per l'identificazione.
+        """@it ;
+    rdfs:seeAlso <https://www.ech.ch/ech/ech-0108>,
+        <https://www.uid.admin.ch/> ;
+    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
+
 systemmap:QvDlxaJ5YMkuZGH6k a schema:SoftwareApplication ;
     rdfs:label "Agrarpolitisches Informationssystem"@de,
         "Agricultural Policy Information System"@en,
@@ -690,315 +999,6 @@ systemmap:QywklUB91myTH0cvS a schema:SoftwareApplication ;
         <https://www.fedlex.admin.ch/eli/cc/2011/770>,
         <https://www.fedlex.admin.ch/eli/cc/2016/565> ;
     systemmap:operatedBy systemmap:QRu4rav1Rlm2mUMWr .
-
-systemmap:SYS022 a schema:SoftwareApplication ;
-    rdfs:label "ACmobile"@de,
-        "ACmobile"@en,
-        "ACmobile"@fr,
-        "ACmobile"@it ;
-    rdfs:comment """
-        ACmobile ist eine plattformunabhängige, mobile Lösung für die elektronische Erfassung von Kontrollergebnissen und Massnahmen.
-        """@de,
-        """
-        ACmobile is a platform-independent mobile solution for the electronic recording of inspection results and measures.
-        """@en,
-        """
-        ACmobile est une solution mobile indépendante de la plateforme pour l'enregistrement électronique des résultats de contrôle et des mesures.
-        """@fr,
-        """
-        ACmobile è una soluzione mobile indipendente dalla piattaforma per la registrazione elettronica dei risultati delle ispezioni e delle misure.
-        """@it ;
-    systemmap:operatedBy systemmap:QmI5VgF2mECWT74i2 .
-
-systemmap:SYS023 a schema:SoftwareApplication ;
-    rdfs:label "Barto"@de,
-        "Barto"@en,
-        "Barto"@fr,
-        "Barto"@it ;
-    rdfs:comment """
-        Barto ist eine digitale Plattform für die Landwirtschaft, die eine effiziente Betriebsführung, Dokumentation und Analyse von Betriebsdaten ermöglicht.
-        Sie integriert verschiedene agronomische und administrative Funktionen und bietet Landwirtinnen und Landwirten eine zentrale Lösung für die Verwaltung ihres Betriebs.
-        Barto wird von der Barto AG betrieben und arbeitet mit Partnern aus der Agrarbranche zusammen, um innovative digitale Lösungen bereitzustellen.
-        """@de,
-        """
-        Barto is a digital platform for agriculture that enables efficient farm management, documentation, and analysis of farm data.
-        It integrates various agronomic and administrative functions and provides farmers with a central solution for managing their operations.
-        Barto is operated by Barto AG and collaborates with partners from the agricultural sector to provide innovative digital solutions.
-        """@en,
-        """
-        Barto est une plateforme numérique pour l'agriculture qui permet une gestion efficace des exploitations, la documentation et l'analyse des données agricoles.
-        Elle intègre diverses fonctions agronomiques et administratives et offre aux agriculteurs une solution centrale pour la gestion de leur exploitation.
-        Barto est exploitée par Barto AG et collabore avec des partenaires du secteur agricole pour fournir des solutions numériques innovantes.
-        """@fr,
-        """
-        Barto è una piattaforma digitale per l'agricoltura che consente una gestione aziendale efficiente, la documentazione e l'analisi dei dati aziendali.
-        Integra diverse funzioni agronomiche e amministrative e offre agli agricoltori una soluzione centrale per la gestione della loro azienda.
-        Barto è gestita da Barto AG e collabora con partner del settore agricolo per fornire soluzioni digitali innovative.
-        """@it ;
-    systemmap:operatedBy systemmap:QDetpcQhSMo4IAeAb .
-
-systemmap:SYS024 a schema:SoftwareApplication ;
-    rdfs:label "Pflanzensorten-Datenbank"@de,
-        "Plant Variety Database"@en,
-        "Base de données des variétés de plantes"@fr,
-        "Database delle varietà vegetali"@it ;
-    rdfs:comment "Die PLUTO-Datenbank enthält Informationen über Pflanzenarten und -sorten von UPOV-Mitgliedern sowie der Organisation für wirtschaftliche Zusammenarbeit und Entwicklung (OECD). Die PLUTO-Datenbank bietet ein Suchinstrument für Sortenbezeichnungen, um die Unterscheidbarkeit neuer Sorten sicherzustellen."@de,
-        "The PLUTO database contains information on plant species and varieties from UPOV members as well as the Organisation for Economic Co-operation and Development (OECD). The PLUTO database provides a search tool for variety denominations to ensure the distinctness of new varieties."@en,
-        "La base de données PLUTO contient des informations sur les espèces et variétés de plantes des membres de l'UPOV ainsi que de l'Organisation de coopération et de développement économiques (OCDE). La base de données PLUTO offre un outil de recherche pour les dénominations variétales afin d'assurer la distinction des nouvelles variétés."@fr,
-        "Il database PLUTO contiene informazioni sulle specie e varietà vegetali dei membri dell'UPOV e dell'Organizzazione per la cooperazione e lo sviluppo economico (OCSE). Il database PLUTO fornisce uno strumento di ricerca per le denominazioni varietali al fine di garantire la distinzione delle nuove varietà."@it ;
-    systemmap:abbreviation "PLUTO"@de,
-        "PLUTO"@en,
-        "PLUTO"@fr,
-        "PLUTO"@it ;
-    systemmap:operatedBy systemmap:QBLH2G6TSKaqhqk4n .
-
-systemmap:SYS025 a schema:SoftwareApplication ;
-    rdfs:label "Betriebs- und Unternehmensregister"@de,
-        "Register of Enterprises and Establishments"@en,
-        "Registre des entreprises et des établissements"@fr,
-        "Registro delle imprese e degli stabilimenti"@it ;
-    rdfs:comment """
-        Das Betriebs- und Unternehmensregister (BUR) umfasst alle Unternehmen und Betriebe des privaten und öffentlichen Rechts, die in der Schweiz domiziliert sind und eine wirtschaftliche Tätigkeit ausüben.
-        Das BUR dient dem BFS als Adressregister für die statistischen Erhebungen bei Unternehmen und Arbeitsstätten.
-        Auch andere Ämter der Bundesverwaltung und zahlreiche Kantone verwenden das BUR zu statistischen oder administrativen Zwecken.
-        """@de,
-        """
-        The Register of Enterprises and Establishments (BUR) includes all private and public legal entities domiciled in Switzerland that engage in economic activity.
-        The BUR serves the FSO as an address register for statistical surveys of businesses and workplaces.
-        Other federal administration offices and numerous cantons also use the BUR for statistical or administrative purposes.
-        """@en,
-        """
-        Le Registre des entreprises et des établissements (REE) recense toutes les entreprises et établissements de droit privé et public domiciliés en Suisse et exerçant une activité économique.
-        Le REE sert de registre d'adresses pour les enquêtes statistiques menées par l'OFS auprès des entreprises et des lieux de travail.
-        D'autres offices de l'administration fédérale ainsi que de nombreux cantons utilisent également le REE à des fins statistiques ou administratives.
-        """@fr,
-        """
-        Il Registro delle imprese e degli stabilimenti (BUR) comprende tutte le imprese e gli stabilimenti di diritto privato e pubblico domiciliati in Svizzera che svolgono un'attività economica.
-        Il BUR serve all'UST come registro degli indirizzi per le rilevazioni statistiche su imprese e luoghi di lavoro.
-        Anche altri uffici dell'amministrazione federale e numerosi cantoni utilizzano il BUR a fini statistici o amministrativi.
-        """@it ;
-    systemmap:abbreviation "BUR"@de,
-        "BUR"@en,
-        "REE"@fr,
-        "BUR"@it ;
-    systemmap:hasLegalBasis <https://www.fedlex.admin.ch/eli/cc/1993/2253_2253_2253> ;
-    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
-
-systemmap:SYS026 a schema:SoftwareApplication ;
-    rdfs:label "e-Deklaration"@de,
-        "e-declaration"@en,
-        "e-déclaration"@fr,
-        "e-dichiarazione"@it ;
-    rdfs:comment "e-dec ist das elektronische Zollanmeldesystem der Schweiz, das Unternehmen ermöglicht, Waren für Import, Export und Transit elektronisch zu deklarieren. Dank seines modularen Aufbaus optimiert es die Zollprozesse, was zu Kosteneinsparungen und höherer Effizienz führt. Besonders hervorzuheben ist, dass e-dec mehrere Kommunikationsstandards unterstützt und jede Zollanmeldung bis zu 99'999 Tarifpositionen enthalten kann."@de,
-        "e-dec is Switzerland's electronic customs declaration system that enables companies to declare goods for import, export, and transit electronically. Designed with a modular structure, it streamlines customs processes, leading to cost savings and increased efficiency. Notably, e-dec supports multiple communication standards and allows each customs declaration to include up to 99'999 tariff headings."@en,
-        "e-dec est le système électronique de déclaration en douane de la Suisse, permettant aux entreprises de déclarer électroniquement les marchandises à l'importation, à l'exportation et en transit. Conçu avec une structure modulaire, il optimise les processus douaniers, entraînant des économies de coûts et une efficacité accrue. Notamment, e-dec prend en charge plusieurs normes de communication et permet à chaque déclaration en douane d'inclure jusqu'à 99'999 positions tarifaires."@fr,
-        "e-dec è il sistema elettronico di dichiarazione doganale della Svizzera che consente alle aziende di dichiarare elettronicamente le merci per l'importazione, l'esportazione e il transito. Progettato con una struttura modulare, ottimizza i processi doganali, portando a risparmi sui costi e a una maggiore efficienza. In particolare, e-dec supporta diversi standard di comunicazione e consente a ogni dichiarazione doganale di includere fino a 99'999 voci tariffarie."@it ;
-    systemmap:abbreviation "e-dec"@de,
-        "e-dec"@en,
-        "e-dec"@fr,
-        "e-dec"@it ;
-    systemmap:operatedBy systemmap:QFKPRpdGa5UISiJlx .
-
-systemmap:SYS027 a schema:SoftwareApplication ;
-    rdfs:label "UID-Register"@de,
-        "UID Register"@en,
-        "Registre UID"@fr,
-        "Registro UID"@it ;
-    rdfs:comment """
-        Das UID-Register ist eine zentrale Datenbank des Bundesamts für Statistik (BFS), die der eindeutigen Identifikation von Unternehmen in der Schweiz dient.
-        Jedes in der Schweiz aktive Unternehmen erhält eine einheitliche Unternehmens-Identifikationsnummer (UID), die administrative Abläufe vereinfacht und die Zusammenarbeit zwischen Behörden effizienter gestaltet.
-        Die im UID-Register enthaltenen Daten beschränken sich auf das für die Identifikation notwendige Minimum.
-        """@de,
-        """
-        The UID Register is a central database of the Federal Statistical Office (FSO) that serves the unique identification of companies in Switzerland.
-        Every company active in Switzerland receives a unique Business Identification Number (UID), which simplifies administrative processes and enhances collaboration between authorities.
-        The data contained in the UID Register is limited to the minimum necessary for identification.
-        """@en,
-        """
-        Le registre UID est une base de données centrale de l'Office fédéral de la statistique (OFS) qui sert à l'identification unique des entreprises en Suisse.
-        Chaque entreprise active en Suisse reçoit un numéro d'identification des entreprises (UID) unique, ce qui simplifie les processus administratifs et améliore la collaboration entre les autorités.
-        Les données contenues dans le registre UID se limitent au minimum nécessaire pour l'identification.
-        """@fr,
-        """
-        Il registro UID è una banca dati centrale dell'Ufficio federale di statistica (UST) che serve all'identificazione univoca delle imprese in Svizzera.
-        Ogni impresa attiva in Svizzera riceve un numero d'identificazione aziendale (UID) unico, che semplifica i processi amministrativi e migliora la collaborazione tra le autorità.
-        I dati contenuti nel registro UID sono limitati al minimo necessario per l'identificazione.
-        """@it ;
-    rdfs:seeAlso <https://www.ech.ch/ech/ech-0108>,
-        <https://www.uid.admin.ch/> ;
-    systemmap:operatedBy systemmap:QNbhMvt3Btta1U1d6 .
-
-systemmap:SYS028 a schema:SoftwareApplication ;
-    rdfs:label "Produkteregister Chemikalien"@de,
-        "Chemical Products Register"@en,
-        "Registre des produits chimiques"@fr,
-        "Registro dei prodotti chimici"@it ;
-    rdfs:comment """
-        Das Produkteregister Chemikalien (RPC) ist die zentrale Datenbank des Bundes für gefährliche chemische Stoffe und Gemische.
-        Es ermöglicht Unternehmen, neue Produkte zu melden oder Zulassungsanträge zu stellen sowie bereits registrierte Produkte zu aktualisieren.
-        Zudem dient es als öffentlich zugängliche Rechercheplattform für gemeldete, angemeldete und zugelassene Chemikalien.
-        """@de,
-        """
-        The Chemical Products Register (RPC) is the federal central database for hazardous chemical substances and mixtures.
-        It enables companies to report new products, submit approval applications, and update already registered products.
-        Additionally, it serves as a publicly accessible research platform for reported, registered, and approved chemicals.
-        """@en,
-        """Le Registre des produits chimiques (RPC) est la base de données centrale fédérale pour les substances chimiques dangereuses et les mélanges.
-        Il permet aux entreprises de déclarer de nouveaux produits, de soumettre des demandes d'approbation et de mettre à jour les produits déjà enregistrés.
-        De plus, il sert de plateforme de recherche accessible au public pour les produits chimiques déclarés, enregistrés et approuvés.
-        """@fr,
-        """Il Registro dei prodotti chimici (RPC) è la banca dati centrale federale per le sostanze chimiche pericolose e le miscele.
-        Consente alle aziende di segnalare nuovi prodotti, presentare domande di approvazione e aggiornare i prodotti già registrati.
-        Inoltre, funge da piattaforma di ricerca accessibile al pubblico per i prodotti chimici segnalati, registrati e approvati.
-        """@it ;
-    systemmap:abbreviation "RPC"@de,
-        "CPR"@en,
-        "RPC"@fr,
-        "RPC"@it ;
-    systemmap:operatedBy systemmap:QGayLcAMcywbigd3M .
-
-systemmap:SYS029 a schema:SoftwareApplication ;
-    rdfs:label "Marktdaten Analyse- und Reporting-System"@de,
-        "Market Data Analysis and Reporting System"@en,
-        "Système d'analyse et de reporting des données de marché"@fr,
-        "Sistema di analisi e reportistica dei dati di mercato"@it ;
-    rdfs:comment """
-        Im Marktdaten Analyse- und Reporting-System (MARS III) werden Preis- und andere wichtige Agrarmarktdaten gesammelt, aggregiert, berechnet, analysiert und für Berichte aufbereitet.
-        """@de,
-        """
-        The Market Data Analysis and Reporting System (MARS III) collects, aggregates, calculates, analyzes, and prepares price and other important agricultural market data for reports.
-        """@en,
-        """
-        Le Système d'analyse et de reporting des données de marché (MARS III) collecte, agrège, calcule, analyse et prépare les données de prix et autres données importantes du marché agricole pour des rapports.
-        """@fr,
-        """
-        Il Sistema di analisi e reportistica dei dati di mercato (MARS III) raccoglie, aggrega, calcola, analizza e prepara i dati sui prezzi e altri dati importanti del mercato agricolo per i rapporti.
-        """@it ;
-    systemmap:abbreviation "MARS III"@de,
-        "MARS III"@en,
-        "MARS III"@fr,
-        "MARS III"@it ;
-    systemmap:operatedBy systemmap:QaVyVVsIDkiDMtQq4 .
-
-systemmap:SYS030 a schema:SoftwareApplication ;
-    rdfs:label "Geografisches Informationssystem"@de,
-        "Geographic Information System"@en,
-        "Système d'information géographique"@fr,
-        "Sistema informativo geografico"@it ;
-    rdfs:comment """
-        Viele Arbeiten und Projekte des BLW haben einen Raumbezug.
-        Das GIS dient der Aufbereitung, Analyse, Auswertung und Darstellung raumbezogener landwirtschaftlicher Daten.
-        Das GIS dient im BLW insbesondere der Nachführung der landwirtschaftlichen Zonengrenzen und Hanglagen.
-        Zudem werden verschiedene andere thematische raumbezogene Fragestellungen im Zusammenhang mit dem Vollzug und der Weiterentwicklung der Agrarpolitik mit dem GIS bearbeitet.
-        """@de,
-        """
-        Many tasks and projects of the FOAG have a spatial reference.
-        The GIS is used for processing, analyzing, evaluating, and visualizing spatial agricultural data.
-        In the FOAG, the GIS is particularly used for updating agricultural zone boundaries and slope areas.
-        In addition, various other thematic spatial issues related to the implementation and further development of agricultural policy are addressed with the GIS.
-        """@en,
-        """
-        De nombreuses tâches et projets de l'OFAG ont une référence spatiale.
-        Le SIG sert à traiter, analyser, évaluer et visualiser les données agricoles spatiales.
-        À l'OFAG, le SIG est notamment utilisé pour la mise à jour des limites des zones agricoles et des pentes.
-        De plus, diverses autres questions spatiales thématiques en lien avec l'exécution et le développement de la politique agricole sont traitées avec le SIG.
-        """@fr,
-        """
-        Molti compiti e progetti dell'UFAG hanno un riferimento spaziale.
-        Il GIS viene utilizzato per l'elaborazione, l'analisi, la valutazione e la visualizzazione dei dati agricoli spaziali.
-        All'UFAG, il GIS è utilizzato in particolare per l'aggiornamento dei confini delle zone agricole e delle aree in pendenza.
-        Inoltre, con il GIS vengono affrontate diverse altre questioni tematiche spaziali legate all'attuazione e allo sviluppo della politica agricola.
-        """@it ;
-    systemmap:abbreviation "GIS-BLW"@de,
-        "GIS-BLW"@en,
-        "GIS-BLW"@fr,
-        "GIS-BLW"@it ;
-    systemmap:hasLegalBasis LwG:art_165_e ;
-    systemmap:operatedBy systemmap:QE8y4MuFWW5BKqK92 .
-
-systemmap:SYS031 a schema:SoftwareApplication ;
-    rdfs:label "Auswertung/Analyse, Lebensmittelsicherheit, Veterinärwesen, Public Health"@de ;
-    rdfs:comment """
-        ALVPH ist das Datawarehouse des Veterinärdienstes Schweiz.
-        Es dient als zentrale Datenplattform, die flexible Abfragen, Standarberichterstattung und statistische Auswertungen über mehrere Datenquellen ermöglicht.
-        Ausserdem verfügt ALVPH über viele graphische Funktionen, die eine attraktive Präsentation der Daten erlauben.
-        """@de ;
-    systemmap:abbreviation "ALVPH"@de ;
-    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
-
-systemmap:SYS032 a schema:SoftwareApplication ;
-    rdfs:label "Informationssystem für meldepflichtige Krankheiten"@de,
-        "Information system for cases of notifiable diseases"@en,
-        "Système d'information pour les maladies à déclaration obligatoire"@fr,
-        "Sistema informativo per le malattie soggette a notifica"@it ;
-    rdfs:comment """
-        Dashboard zur Visualisierung und Filterung verknüpfter Tierseuchendaten, die vom Bundesamt für Lebensmittelsicherheit und Veterinärwesen veröffentlicht werden.
-        """@de,
-        """
-        Dashboard for the visualization and filtering of linked animal diseases data published by the Swiss Federal Food Safety and Veterinary Office.
-        """@en,
-        """
-        Tableau de bord pour la visualisation et le filtrage des données liées aux maladies animales publiées par l'Office fédéral de la sécurité alimentaire et des affaires vétérinaires.
-        """@fr,
-        """
-        Dashboard per la visualizzazione e il filtraggio dei dati sulle malattie animali pubblicati dall'Ufficio federale della sicurezza alimentare e di veterinaria.
-        """@it ;
-    rdfs:seeAlso <https://github.com/digital-sustainability/blv-infosm> ;
-    dcat:landingPage <https://www.dashboard.blv.admin.ch/> ;
-    systemmap:abbreviation "InfoSM"@de,
-        "InfoSM"@en,
-        "InfoSM"@fr,
-        "InfoSM"@it ;
-    systemmap:operatedBy systemmap:QsFdxnjM8hgUdzVT5 .
-
-systemmap:SYS033 a schema:SoftwareApplication ;
-    rdfs:label "Apinella"@de ;
-    rdfs:comment """
-        Software insbesondere für die Früherkennungsprogramm des kleiner Beutenkäfer bei Bienen.
-        """@de ;
-    dcat:landingPage <https://www.apinella.ch/> ;
-    systemmap:operatedBy systemmap:Q3Rf79NI3Pm1rfOlN .
-
-systemmap:SYS034 a schema:SoftwareApplication ;
-    rdfs:label "Traces"@de ;
-    rdfs:comment """
-        Alle Personen und Firmen, die am Import- oder Exportprozess für den internationalen Handel von Tieren, Waren tierischen Ursprungs und gewissen Produkten nicht-tierischen Ursprungs beteiligt sind, müssen sich in Traces registrieren lassen.
-        Es handelt sich um ein eine Webanwendung der Europäischen Union und unterstützt den grenzüberschreitenden Verkehr von Tieren, Lebensmitteln und tierischen Nebenprodukten.
-        """@de ;
-    systemmap:operatedBy systemmap:QhM5kJNFhO8vOAEdK .
-
-systemmap:SYS035 a schema:SoftwareApplication ;
-    rdfs:label "eMapis"@de ;
-    rdfs:comment """
-        eMapis wurde entwickelt, um die veraltete MAPIS-Applikation abzulösen und die digitale Verwaltung von Finanzhilfegesuchen, wie Bundesbeiträge und zinslose Darlehen, zu ermöglichen.
-        Das System zentralisiert die Erfassung und Verwaltung von Daten sowie Dokumenten, wodurch Doppelerfassungen vermieden werden.
-        Mit automatisierten Workflows, einer zentralen Benutzerverwaltung und der Integration von GIS-Daten (sowie zukünftig Betriebsdaten) verbessert eMapis die Transparenz und Effizienz in der Bearbeitung der Finanzhilfefälle.
-        """@de ;
-    systemmap:operatedBy systemmap:QG8fSveeGZNcYzoUN .
-
-systemmap:SYS041 a schema:SoftwareApplication ;
-    rdfs:label "Zentrale Auswertung von Agrarumweltindikatoren"@de ;
-    rdfs:comment """
-        Die 'ZA-AUI: Betriebsrückmeldung' ermöglicht den Teilnehmenden am Projekt ZA-AUI die berechneten Agrarumweltindikatoren (AUI) ihres Betriebs online abzurufen, für welche sie jährlich Daten an Agroscope liefern.
-        Die eigenen Betriebsergebnisse können mit den AUI-Ergebnissen desselben Betriebstyps aus dem ZA-AUI-Betriebsnetz verglichen werden.
-        """@de ;
-    dcat:landingPage <https://apps.agroscope.info/sp/za-aui/2/app/datenreihe>,
-        <https://www.agrarumweltindikatoren.ch>,
-        <https://www.za-aui.ch> ;
-    systemmap:abbreviation "ZA-AUI"@de ;
-    systemmap:operatedBy staatskalender:20050530 .
-
-systemmap:SYS042 a schema:SoftwareApplication ;
-    rdfs:label "DigiAgriFoodCH Systemlandkarte"@de,
-        "DigiAgriFoodCH System Map"@en,
-        "Carte du système DigiAgriFoodCH"@fr,
-        "Mappa del sistema DigiAgriFoodCH"@it ;
-    rdfs:comment "Ein Visualisierungstool für Informationen über IT-Systeme, die darin enthaltenen Daten und deren betreibende Organisationen im Schweizer Agrar- und Ernährungssektor."@de,
-        "A visualization tool for information about IT systems, the data those contain and their operating organizations in the Swiss agri-food sector."@en,
-        "Un outil de visualisation des informations sur les systèmes informatiques, les données qu'ils contiennent et les organisations qui les exploitent dans le secteur agroalimentaire suisse."@fr,
-        "Uno strumento di visualizzazione delle informazioni sui sistemi IT, i dati in essi contenuti e le organizzazioni che li gestiscono nel settore agroalimentare svizzero."@it ;
-    dcat:landingPage <https://blw-ofag-ufag.github.io/system-map/> ;
-    systemmap:operatedBy systemmap:QFAwQAwxBcNnaURgO .
 
 systemmap:Q1KtKkrBMoK25AKVA a systemmap:CantonalOrganization ;
     rdfs:label "Direktzahlungen und Beiträge"@de ;
@@ -2174,30 +2174,7 @@ systemmap:QzXI1C2DYjDriK2F8 a systemmap:FederalOrganization ;
 staatskalender:20050530 a systemmap:FederalOrganization ;
     rdfs:label "Monitoring des Agrarumweltsystems Schweiz MAUS"@de .
 
-systemmap:INF003 a systemmap:Identifier ;
-    rdfs:label "UID-Nummer"@de,
-        "UID Number"@en,
-        "Numéro UID"@fr,
-        "Numero UID"@it ;
-    rdfs:comment """
-        Jedes in der Schweiz aktive Unternehmen erhält eine einheitliche Unternehmens-Identifikationsnummer (UID).
-        Die Verwendung der UID ermöglicht eine administrative Entlastung der Unternehmen sowie eine effizientere Zusammenarbeit zwischen den Behörden.
-        """@de,
-        """
-        Every company active in Switzerland receives a unique Business Identification Number (UID).
-        The use of the UID facilitates administrative relief for companies and enables more efficient collaboration between authorities.
-        """@en,
-        """
-        Chaque entreprise active en Suisse reçoit un numéro d'identification des entreprises (UID) unique.
-        L'utilisation de l'UID permet un allègement administratif pour les entreprises et une collaboration plus efficace entre les autorités.
-        """@fr,
-        """
-        Ogni azienda attiva in Svizzera riceve un numero d'identificazione aziendale (UID) unico.
-        L'uso dell'UID facilita l'alleggerimento amministrativo per le aziende e consente una collaborazione più efficiente tra le autorità.
-        """@it ;
-    systemmap:containedIn systemmap:SYS027 .
-
-systemmap:INF004 a systemmap:Identifier ;
+systemmap:Q3jZwzvmFKsXRWiI a systemmap:Identifier ;
     rdfs:label "BUR-Nummer"@de,
         "BUR Number"@en,
         "Numéro BUR"@fr,
@@ -2222,9 +2199,44 @@ systemmap:INF004 a systemmap:Identifier ;
         "BURNR"@en,
         "BURNR"@fr,
         "BURNR"@it ;
-    systemmap:containedIn systemmap:SYS025 .
+    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
 
-systemmap:INF005 a systemmap:Information ;
+systemmap:QDLEUPczkJ9AWZeC a systemmap:Identifier ;
+    rdfs:label "UID-Nummer"@de,
+        "UID Number"@en,
+        "Numéro UID"@fr,
+        "Numero UID"@it ;
+    rdfs:comment """
+        Jedes in der Schweiz aktive Unternehmen erhält eine einheitliche Unternehmens-Identifikationsnummer (UID).
+        Die Verwendung der UID ermöglicht eine administrative Entlastung der Unternehmen sowie eine effizientere Zusammenarbeit zwischen den Behörden.
+        """@de,
+        """
+        Every company active in Switzerland receives a unique Business Identification Number (UID).
+        The use of the UID facilitates administrative relief for companies and enables more efficient collaboration between authorities.
+        """@en,
+        """
+        Chaque entreprise active en Suisse reçoit un numéro d'identification des entreprises (UID) unique.
+        L'utilisation de l'UID permet un allègement administratif pour les entreprises et une collaboration plus efficace entre les autorités.
+        """@fr,
+        """
+        Ogni azienda attiva in Svizzera riceve un numero d'identificazione aziendale (UID) unico.
+        L'uso dell'UID facilita l'alleggerimento amministrativo per le aziende e consente una collaborazione più efficiente tra le autorità.
+        """@it ;
+    systemmap:containedIn systemmap:QuEtT7joC8HXVSfF .
+
+systemmap:Q1AkhvKmzBiJFCTc a systemmap:Information ;
+    rdfs:label "Agrarmarktdaten"@de,
+        "agricultural market data"@en,
+        "données du marché agricole"@fr,
+        "dati di mercato agricolo"@it ;
+    rdfs:comment "Marktdaten enthalten Preise, Mengen, Produktionssysteme."@de,
+        "Market data includes prices, quantities, production systems."@en,
+        "Les données de marché comprennent les prix, les quantités, les systèmes de production."@fr,
+        "I dati di mercato comprendono prezzi, quantità e sistemi di produzione."@it ;
+    systemmap:containedIn systemmap:Qc6kZqxTyS0gFGCY ;
+    systemmap:informs systemmap:QRT6X0n1ML8vwHUW .
+
+systemmap:Q4BoMPavXD5gIObm a systemmap:Information ;
     rdfs:label "Tieridentifikationsdaten"@de,
         "Animal identification data"@en,
         "Données d'identification des animaux"@fr,
@@ -2247,7 +2259,26 @@ systemmap:INF005 a systemmap:Information ;
         """@it ;
     systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
 
-systemmap:INF006 a systemmap:Information ;
+systemmap:Q4hqylQaEIsYGXMo a systemmap:Information ;
+    rdfs:label "Verschiebung von Mineraldüngern"@de,
+        "Movement of Mineral Fertilizers"@en,
+        "Déplacement des engrais minéraux"@fr,
+        "Spostamento dei fertilizzanti minerali"@it ;
+    rdfs:comment """
+        Die Verschiebung von Mineraldüngern umfasst die Erfassung und Meldung aller Zu- und Abgänge mineralischer Düngemittel, einschliesslich Käufe, Verkäufe und betrieblicher Transfers.
+        """@de,
+        """
+        The movement of mineral fertilizers includes the recording and reporting of all inflows and outflows of mineral fertilizers, including purchases, sales, and internal transfers.
+        """@en,
+        """
+        Le déplacement des engrais minéraux comprend l'enregistrement et la déclaration de toutes les entrées et sorties d'engrais minéraux, y compris les achats, les ventes et les transferts internes.
+        """@fr,
+        """
+        Lo spostamento dei fertilizzanti minerali include la registrazione e la segnalazione di tutti gli afflussi e deflussi di fertilizzanti minerali, compresi acquisti, vendite e trasferimenti interni.
+        """@it ;
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
+
+systemmap:Q7mhWQjPZiSFc8dU a systemmap:Information ;
     rdfs:label "Tierereignisdaten"@de,
         "Animal event data"@en,
         "Données d'événements animaux"@fr,
@@ -2270,30 +2301,68 @@ systemmap:INF006 a systemmap:Information ;
         """@it ;
     systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
 
-systemmap:INF007 a systemmap:Information ;
-    rdfs:label "Meldepflichtdaten (Schafe & Ziegen)"@de,
-        "Mandatory reporting data (sheep & goats)"@en,
-        "Données à déclaration obligatoire (moutons & chèvres)"@fr,
-        "Dati soggetti a obbligo di notifica (pecore & capre)"@it ;
+systemmap:Q8JpqvyO4LQwEM5s a systemmap:Information ;
+    rdfs:label "Globaler Sortenkatalog"@de,
+        "Global variety catalog"@en,
+        "Catalogue mondial des variétés"@fr,
+        "Catalogo globale delle varietà"@it ;
     rdfs:comment """
-        Beinhaltet spezifische Daten, die aufgrund erweiterter Meldepflichten für Schafe und Ziegen erfasst werden müssen.
-        Dazu gehören Meldungen zu Geburten (innerhalb von 30 Tagen) sowie zu Verendungen, Zu- und Abgängen sowie Schlachtungen (innerhalb von 3 Tagen).
-        """@de,
+        Informationen zu Pflanzensorten aus UPOV-Mitgliedsländern sowie der Organisation für wirtschaftliche Zusammenarbeit und Entwicklung (OECD).
+        Diese Sortenliste dient als zentrales Register für Sortenbezeichnungen und unterstützt bei der Überprüfung der Unterscheidbarkeit neuer Sorten."""@de,
         """
-        Includes specific data that must be recorded due to extended reporting obligations for sheep and goats.
-        This includes reports on births (within 30 days), as well as deaths, arrivals and departures, and slaughter (within 3 days).
+        Information on plant varieties from UPOV member countries as well as the Organisation for Economic Co-operation and Development (OECD).
+        This variety list serves as a central register for variety denominations and supports the verification of the distinctness of new varieties.
         """@en,
         """
-        Contient des données spécifiques qui doivent être enregistrées en raison d'obligations de déclaration étendues pour les moutons et les chèvres.
-        Cela comprend les déclarations de naissances (dans les 30 jours), ainsi que les décès, arrivées et départs, et abattages (dans les 3 jours).
+        Informations sur les variétés végétales des pays membres de l'UPOV ainsi que de l'Organisation de coopération et de développement économiques (OCDE).
+        Cette liste de variétés sert de registre central pour les dénominations de variétés et aide à vérifier la distinction des nouvelles variétés.
         """@fr,
         """
-        Contiene dati specifici che devono essere registrati a causa di obblighi di notifica estesi per pecore e capre.
-        Ciò include le segnalazioni di nascite (entro 30 giorni), nonché decessi, arrivi e partenze e macellazioni (entro 3 giorni).
+        Informazioni sulle varietà vegetali provenienti dai paesi membri dell'UPOV e dall'Organizzazione per la cooperazione e lo sviluppo economico (OCSE).
+        Questo elenco di varietà funge da registro centrale per le denominazioni varietali e supporta la verifica della distinzione delle nuove varietà.
         """@it ;
-    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
+    systemmap:containedIn systemmap:QgjZ0efLbuCR2HvN ;
+    systemmap:informedBy systemmap:Qpqrv6Ul05KJySTs .
 
-systemmap:INF008 a systemmap:Information ;
+systemmap:Q8cKNg0hfPy97TUB a systemmap:Information ;
+    rdfs:label "Details zu Unternehmen"@de,
+        "Company details"@en,
+        "Détails sur les entreprises"@fr,
+        "Dettagli sulle imprese"@it ;
+    rdfs:comment """
+        Anzahl beschäftigte Personen nach Geschlecht und Arbeitszeit, Grundkapital der Aktiengesellschaften, Umsatzzahlen, Datum des Eintrags oder der Löschung im Handelsregister, Datum der Bekanntgabe der Gründung oder Schliessung eines Unternehmens oder Betriebs.
+        """@de,
+        """
+        Number of employees by gender and working hours, share capital of joint-stock companies, revenue figures, date of registration or deletion in the commercial register, date of announcement of the establishment or closure of a company or business.
+        """@en,
+        """
+        Nombre d'employés selon le sexe et le temps de travail, capital social des sociétés anonymes, chiffres d'affaires, date d'inscription ou de suppression au registre du commerce, date d'annonce de la création ou de la fermeture d'une entreprise ou d'un établissement.
+        """@fr,
+        """
+        Numero di dipendenti per genere e orario di lavoro, capitale sociale delle società per azioni, dati di fatturato, data di registrazione o cancellazione nel registro commerciale, data di annuncio della fondazione o chiusura di un'azienda o impresa.
+        """@it ;
+    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+
+systemmap:Q9J1HTMKIxnCgmYc a systemmap:Information ;
+    rdfs:label "Pflanzenschutzmittel"@de,
+        "Plant Protection Products"@en,
+        "Produits phytosanitaires"@fr,
+        "Prodotti fitosanitari"@it ;
+    rdfs:comment """
+        Liste der in der Schweiz erlaubten Pflanzenschutzmittel, deren chemische Zusammensetzung, W-Nummern und Bewilligungsinhaber.
+        """@de,
+        """
+        List of plant protection products authorized in Switzerland, including their chemical composition, W-numbers, and authorization holders.
+        """@en,
+        """
+        Liste des produits phytosanitaires autorisés en Suisse, y compris leur composition chimique, numéros W et titulaires d'autorisation.
+        """@fr,
+        """
+        Elenco dei prodotti fitosanitari autorizzati in Svizzera, inclusa la loro composizione chimica, i numeri W e i titolari dell'autorizzazione.
+        """@it ;
+    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
+
+systemmap:QAUWzyCpeGZ6vVil a systemmap:Information ;
     rdfs:label "Daten zu Tierhaltern"@de,
         "Data on animal owners"@en,
         "Données sur les détenteurs d’animaux"@fr,
@@ -2319,21 +2388,172 @@ systemmap:INF008 a systemmap:Information ;
         Questi dati garantiscono che tutti i movimenti e gli eventi degli animali possano essere correttamente attribuiti a un detentore, essenziale per la tracciabilità e il rispetto dei requisiti legali.
         """@it ;
     systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ ;
-    systemmap:informedBy systemmap:INF014 .
+    systemmap:informedBy systemmap:QvNriWslaOR5xkdw .
 
-systemmap:INF010 a systemmap:Information ;
-    rdfs:label "Nationaler Sortenkatalog"@de,
-        "National variety catalog"@en,
-        "Catalogue national des variétés"@fr,
-        "Catalogo nazionale delle varietà"@it ;
-    rdfs:comment "Katalog von anerkannten landwirtschaftlich genutzten Pflanzensorten in der Schweiz. Die Informationen dazu werden von den Züchtern erfasst."@de,
-        "Catalog of recognized agricultural plant varieties used in Switzerland. The information is recorded by breeders."@en,
-        "Catalogue des variétés de plantes agricoles reconnues utilisées en Suisse. Les informations sont enregistrées par les sélectionneurs."@fr,
-        "Catalogo delle varietà di piante agricole riconosciute utilizzate in Svizzera. Le informazioni sono registrate dai selezionatori."@it ;
-    systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj ;
-    systemmap:informedBy systemmap:INF012 .
+systemmap:QDmJeWK7EOnMqRLs a systemmap:Information ;
+    rdfs:label "Auflagen zur Anwendung von Pflanzenschutzmitteln"@de,
+        "Conditions for the Use of Plant Protection Products"@en,
+        "Conditions d'utilisation des produits phytosanitaires"@fr,
+        "Condizioni per l'uso dei prodotti fitosanitari"@it ;
+    rdfs:comment """
+        Bestimmungen und Einschränkungen, die bei der Anwendung von Pflanzenschutzmitteln zu beachten sind, einschliesslich Dosierung, Anwendungszeitpunkt und Schutzmassnahmen.
+        """@de,
+        """
+        Regulations and restrictions to be observed when using plant protection products, including dosage, application timing, and protective measures.
+        """@en,
+        """
+        Règlements et restrictions à respecter lors de l'utilisation de produits phytosanitaires, y compris le dosage, le moment de l'application et les mesures de protection.
+        """@fr,
+        """
+        Regolamenti e restrizioni da osservare nell'uso dei prodotti fitosanitari, inclusi dosaggio, tempistica dell'applicazione e misure protettive.
+        """@it ;
+    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
 
-systemmap:INF012 a systemmap:Information ;
+systemmap:QECM4KqStG9yBva6 a systemmap:Information ;
+    rdfs:label "Verschiebung von Hof- und Recyclingdünger"@de,
+        "Movement of Farmyard and Recycled Fertilizers"@en,
+        "Déplacement des engrais de ferme et recyclés"@fr,
+        "Spostamento dei fertilizzanti aziendali e riciclati"@it ;
+    rdfs:comment """
+        Die Verschiebung von Hof- und Recyclingdüngern umfasst die Erfassung und Meldung aller Zu- und Abgänge, einschliesslich Käufe, Verkäufe und betrieblicher Transfers.
+        """@de,
+        """
+        The movement of farmyard and recycled fertilizers includes the recording and reporting of all inflows and outflows, including purchases, sales, and internal transfers.
+        """@en,
+        """
+        Le déplacement des engrais de ferme et recyclés comprend l'enregistrement et la déclaration de toutes les entrées et sorties, y compris les achats, les ventes et les transferts internes.
+        """@fr,
+        """
+        Lo spostamento dei fertilizzanti aziendali e riciclati include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
+        """@it ;
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
+
+systemmap:QFyGV7l0kN4qgA8u a systemmap:Information ;
+    rdfs:label "Kulturen und Schaderreger"@de,
+        "Crops and Pests"@en,
+        "Cultures et organismes nuisibles"@fr,
+        "Colture e organismi nocivi"@it ;
+    rdfs:comment """
+        Liste der Kulturen und Schaderreger, für die in der Schweiz bereits eine Pflanzenschutzmittelbewilligung erteilt wurde.
+        """@de,
+        """
+        List of crops and pests for which a plant protection product authorization has already been granted in Switzerland.
+        """@en,
+        """
+        Liste des cultures et organismes nuisibles pour lesquels une autorisation de produit phytosanitaire a déjà été accordée en Suisse.
+        """@fr,
+        """
+        Elenco delle colture e degli organismi nocivi per i quali è già stata concessa un'autorizzazione per un prodotto fitosanitario in Svizzera.
+        """@it ;
+    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
+
+systemmap:QIsQ6LSUJc3xbG9B a systemmap:Information ;
+    rdfs:label "Biozide"@de,
+        "Biocides"@en,
+        "Biocides"@fr,
+        "Biocidi"@it ;
+    rdfs:comment """
+        Produkte zur Bekämpfung von Schadorganismen. Mitenthalten sind auch parallel importierte Pflanzenschutzmittel, also solche, die aus anderen Ländern eingeführt werden.
+        """@de,
+        """
+        Products used to combat harmful organisms. This also includes parallel-imported plant protection products, meaning those imported from other countries.
+        """@en,
+        """
+        Produits utilisés pour lutter contre les organismes nuisibles. Cela inclut également les produits phytosanitaires importés en parallèle, c'est-à-dire en provenance d'autres pays.
+        """@fr,
+        """
+        Prodotti utilizzati per combattere gli organismi nocivi. Sono inclusi anche i prodotti fitosanitari importati parallelamente da altri paesi.
+        """@it ;
+    systemmap:containedIn systemmap:QHEaRYIgvZ3xrDLo .
+
+systemmap:QLXw4VofhYbzXVNKC a systemmap:Information ;
+    rdfs:label "Daten zur Milchverwertung"@de,
+        "Data on milk utilization"@en,
+        "Données sur la valorisation du lait"@fr,
+        "Dati sull'utilizzo del latte"@it ;
+    rdfs:comment "Diese Daten sind essenziell für die Berechnung und Auszahlung von Zulagen für verkäste Milch sowie für die Fütterung ohne Silage durch das Bundesamt für Landwirtschaft (BLW)."@de,
+        "These data are essential for the calculation and payment of subsidies for cheesed milk as well as for feeding without silage by the Federal Office for Agriculture (BLW)."@en,
+        "Ces données sont essentielles pour le calcul et le paiement des subventions pour le lait transformé en fromage ainsi que pour l'alimentation sans ensilage par l'Office fédéral de l'agriculture (OFAG)."@fr,
+        "Questi dati sono essenziali per il calcolo e il pagamento dei sussidi per il latte trasformato in formaggio e per l'alimentazione senza insilato da parte dell'Ufficio federale dell'agricoltura (UFAG)."@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+
+systemmap:QPCig1xdekUHDV4r a systemmap:Information ;
+    rdfs:label "Milchstatistik"@de,
+        "Milk statistics"@en,
+        "Statistiques du lait"@fr,
+        "Statistiche del latte"@it ;
+    rdfs:comment "Monatliche Statistiken und Mehrjahresvergleiche, die Angaben über die produzierte Milch und deren Verarbeitung in verschiedene Produktgruppen enthalten."@de,
+        "Monthly statistics and multi-year comparisons containing information on the milk produced and its processing into different product groups."@en,
+        "Statistiques mensuelles et comparaisons pluriannuelles contenant des informations sur le lait produit et sa transformation en différentes catégories de produits."@fr,
+        "Statistiche mensili e confronti pluriennali contenenti informazioni sul latte prodotto e sulla sua trasformazione in diverse categorie di prodotti."@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+
+systemmap:QRT6X0n1ML8vwHUW a systemmap:Information ;
+    rdfs:label "Linked Data"@de,
+        "Linked Data"@en,
+        "Linked Data"@fr,
+        "Linked Data"@it ;
+    systemmap:containedIn systemmap:QHFSc6xgsHF70IlUd,
+        systemmap:QpLZd1ojPxF0CvH28 .
+
+systemmap:QUZP05KJlIyCX9A8 a systemmap:Information ;
+    rdfs:label "Zubereitungen"@de,
+        "Preparations"@en,
+        "Préparations"@fr,
+        "Preparazioni"@it ;
+    rdfs:comment """
+        Mischungen oder Lösungen aus zwei oder mehr Stoffen.
+        """@de,
+        """
+        Mixtures or solutions composed of two or more substances.
+        """@en,
+        """
+        Mélanges ou solutions composés de deux ou plusieurs substances.
+        """@fr,
+        """
+        Miscele o soluzioni composte da due o più sostanze.
+        """@it ;
+    systemmap:containedIn systemmap:QHEaRYIgvZ3xrDLo .
+
+systemmap:QUlfRYzH3b0gx7VX a systemmap:Information ;
+    rdfs:label "Verschiebung von Pflanzenschutzmitteln"@de,
+        "Movement of Plant Protection Products"@en,
+        "Déplacement des produits phytosanitaires"@fr,
+        "Spostamento dei prodotti fitosanitari"@it ;
+    rdfs:comment """
+        Die Verschiebung von Pflanzenschutzmitteln umfasst die Erfassung und Meldung aller Zu- und Abgänge von Pflanzenschutzmitteln, einschliesslich Käufe, Verkäufe und betrieblicher Transfers.
+        """@de,
+        """
+        The movement of plant protection products includes the recording and reporting of all inflows and outflows, including purchases, sales, and internal transfers.
+        """@en,
+        """
+        Le déplacement des produits phytosanitaires comprend l'enregistrement et la déclaration de toutes les entrées et sorties, y compris les achats, les ventes et les transferts internes.
+        """@fr,
+        """
+        Lo spostamento dei prodotti fitosanitari include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
+        """@it ;
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
+
+systemmap:QZBHsREMx369FArg a systemmap:Information ;
+    rdfs:label "Dünger"@de,
+        "Fertilizers"@en,
+        "Engrais"@fr,
+        "Fertilizzanti"@it ;
+    rdfs:comment """
+        Produkte zur Boden- und Pflanzendüngung.
+        """@de,
+        """
+        Products for soil and plant fertilization.
+        """@en,
+        """
+        Produits pour la fertilisation des sols et des plantes.
+        """@fr,
+        """
+        Prodotti per la fertilizzazione del suolo e delle piante.
+        """@it ;
+    systemmap:containedIn systemmap:QHEaRYIgvZ3xrDLo .
+
+systemmap:Qb2FM7pKN60PrRwU a systemmap:Information ;
     rdfs:label "Globale Pflanzenliste"@de,
         "Global plant list"@en,
         "Liste globale des plantes"@fr,
@@ -2362,32 +2582,103 @@ systemmap:INF012 a systemmap:Information ;
         Questi cosiddetti codici UPOV sono generalmente composti da cinque lettere per il genere e tre lettere per la specie. Ad esempio, <tt>PRUNU_ARM</tt> rappresenta <i>Prunus armeniaca</i> (albicocco).
         Questo sistema facilita la classificazione e lo scambio di informazioni sulle varietà vegetali.
         """@it ;
-    systemmap:containedIn systemmap:SYS024 .
+    systemmap:containedIn systemmap:QgjZ0efLbuCR2HvN .
 
-systemmap:INF013 a systemmap:Information ;
-    rdfs:label "Globaler Sortenkatalog"@de,
-        "Global variety catalog"@en,
-        "Catalogue mondial des variétés"@fr,
-        "Catalogo globale delle varietà"@it ;
+systemmap:Qe6Nt3cqogxz2d10g a systemmap:Information ;
+    rdfs:label "Daten zur Milchproduktion"@de,
+        "Data on milk production"@en,
+        "Données sur la production laitière"@fr,
+        "Dati sulla produzione di latte"@it ;
     rdfs:comment """
-        Informationen zu Pflanzensorten aus UPOV-Mitgliedsländern sowie der Organisation für wirtschaftliche Zusammenarbeit und Entwicklung (OECD).
-        Diese Sortenliste dient als zentrales Register für Sortenbezeichnungen und unterstützt bei der Überprüfung der Unterscheidbarkeit neuer Sorten."""@de,
+        Monatliche Produktionsmengen (in kg) der im Vormonat gelieferten Kuh- und Büffelmilch von allen Milchproduzenten.
+        Das BLW benötigt diese Information für die Ausrichtung der Zulage für Verkehrsmilch.
+        """@de,
         """
-        Information on plant varieties from UPOV member countries as well as the Organisation for Economic Co-operation and Development (OECD).
-        This variety list serves as a central register for variety denominations and supports the verification of the distinctness of new varieties.
+        Monthly production quantities (in kg) of cow and buffalo milk delivered in the previous month by all milk producers.
+        The BLW requires this information for the allocation of the subsidy for market milk.
         """@en,
         """
-        Informations sur les variétés végétales des pays membres de l'UPOV ainsi que de l'Organisation de coopération et de développement économiques (OCDE).
-        Cette liste de variétés sert de registre central pour les dénominations de variétés et aide à vérifier la distinction des nouvelles variétés.
+        Quantités de production mensuelles (en kg) du lait de vache et de bufflonne livré le mois précédent par tous les producteurs de lait.
+        L'OFAG a besoin de ces informations pour l'octroi de la subvention pour le lait de consommation.
         """@fr,
         """
-        Informazioni sulle varietà vegetali provenienti dai paesi membri dell'UPOV e dall'Organizzazione per la cooperazione e lo sviluppo economico (OCSE).
-        Questo elenco di varietà funge da registro centrale per le denominazioni varietali e supporta la verifica della distinzione delle nuove varietà.
+        Quantità di produzione mensili (in kg) del latte di mucca e bufala consegnato nel mese precedente da tutti i produttori di latte.
+        L'UFAG necessita di queste informazioni per l'assegnazione del sussidio per il latte di consumo.
         """@it ;
-    systemmap:containedIn systemmap:SYS024 ;
-    systemmap:informedBy systemmap:INF010 .
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
-systemmap:INF015 a systemmap:Information ;
+systemmap:Ql5KyePu7JtGiE3V a systemmap:Information ;
+    rdfs:label "Produktekatalog"@de,
+        "Product catalog"@en,
+        "Catalogue de produits"@fr,
+        "Catalogo dei prodotti"@it ;
+    rdfs:comment """
+        Sammlung von Informationen zu Pflanzenschutzmittel-, Futtermittel-, Mineraldünger-, Hof- und Recyclingdünger-Produkten.
+        Das beinhaltet jeweilige Identifikatoren, Namen, Beschreibungen, Inhaltsstoffe und Mengen etc.
+        """@de,
+        """
+        Collection of information on plant protection products, feed, mineral fertilizers, farm and recycled fertilizers.
+        This includes respective identifiers, names, descriptions, ingredients, and quantities, etc.
+        """@en,
+        """
+        Collection d'informations sur les produits phytosanitaires, les aliments pour animaux, les engrais minéraux, les engrais de ferme et les engrais recyclés.
+        Cela inclut les identifiants respectifs, les noms, les descriptions, les ingrédients et les quantités, etc.
+        """@fr,
+        """
+        Raccolta di informazioni sui prodotti fitosanitari, i mangimi, i fertilizzanti minerali, i fertilizzanti agricoli e quelli riciclati.
+        Ciò include gli identificatori, i nomi, le descrizioni, gli ingredienti e le quantità, ecc.
+        """@it ;
+    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF ;
+    systemmap:informedBy systemmap:Q9J1HTMKIxnCgmYc,
+        systemmap:QZBHsREMx369FArg .
+
+systemmap:QoBRgq7STLbZfEze a systemmap:Information ;
+    rdfs:label "Meldepflichtdaten (Schafe & Ziegen)"@de,
+        "Mandatory reporting data (sheep & goats)"@en,
+        "Données à déclaration obligatoire (moutons & chèvres)"@fr,
+        "Dati soggetti a obbligo di notifica (pecore & capre)"@it ;
+    rdfs:comment """
+        Beinhaltet spezifische Daten, die aufgrund erweiterter Meldepflichten für Schafe und Ziegen erfasst werden müssen.
+        Dazu gehören Meldungen zu Geburten (innerhalb von 30 Tagen) sowie zu Verendungen, Zu- und Abgängen sowie Schlachtungen (innerhalb von 3 Tagen).
+        """@de,
+        """
+        Includes specific data that must be recorded due to extended reporting obligations for sheep and goats.
+        This includes reports on births (within 30 days), as well as deaths, arrivals and departures, and slaughter (within 3 days).
+        """@en,
+        """
+        Contient des données spécifiques qui doivent être enregistrées en raison d'obligations de déclaration étendues pour les moutons et les chèvres.
+        Cela comprend les déclarations de naissances (dans les 30 jours), ainsi que les décès, arrivées et départs, et abattages (dans les 3 jours).
+        """@fr,
+        """
+        Contiene dati specifici che devono essere registrati a causa di obblighi di notifica estesi per pecore e capre.
+        Ciò include le segnalazioni di nascite (entro 30 giorni), nonché decessi, arrivi e partenze e macellazioni (entro 3 giorni).
+        """@it ;
+    systemmap:containedIn systemmap:QU88cJmqj8nBRl2KZ .
+
+systemmap:Qpqrv6Ul05KJySTs a systemmap:Information ;
+    rdfs:label "Nationaler Sortenkatalog"@de,
+        "National variety catalog"@en,
+        "Catalogue national des variétés"@fr,
+        "Catalogo nazionale delle varietà"@it ;
+    rdfs:comment "Katalog von anerkannten landwirtschaftlich genutzten Pflanzensorten in der Schweiz. Die Informationen dazu werden von den Züchtern erfasst."@de,
+        "Catalog of recognized agricultural plant varieties used in Switzerland. The information is recorded by breeders."@en,
+        "Catalogue des variétés de plantes agricoles reconnues utilisées en Suisse. Les informations sont enregistrées par les sélectionneurs."@fr,
+        "Catalogo delle varietà di piante agricole riconosciute utilizzate in Svizzera. Le informazioni sono registrate dai selezionatori."@it ;
+    systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj ;
+    systemmap:informedBy systemmap:Qb2FM7pKN60PrRwU .
+
+systemmap:QzcK9O3XZFxVW1IS a systemmap:Information ;
+    rdfs:label "Daten zur Milchsegmentierung"@de,
+        "Data on milk segmentation"@en,
+        "Données sur la segmentation du lait"@fr,
+        "Dati sulla segmentazione del latte"@it ;
+    rdfs:comment "Daten zur Segmentierung der Milchverwertung gemäss dem BOM1-Reglement."@de,
+        "Data on the segmentation of milk utilization according to the BOM1 regulation."@en,
+        "Données sur la segmentation de la valorisation du lait selon le règlement BOM1."@fr,
+        "Dati sulla segmentazione dell'utilizzo del latte secondo il regolamento BOM1."@it ;
+    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+
+systemmap:QzuDlnYUQMk3HaCb a systemmap:Information ;
     rdfs:label "Strukturdaten"@de,
         "Structural data"@en,
         "Données structurelles"@fr,
@@ -2413,300 +2704,29 @@ systemmap:INF015 a systemmap:Information ;
         L'indagine serve per l'analisi statistica dell'agricoltura, l'aggiornamento del registro delle aziende e le decisioni di politica agricola.
         """@it ;
     systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
-    systemmap:informs systemmap:INF030 .
+    systemmap:informs systemmap:QX1qchbxSZKWI6Up .
 
-systemmap:INF025 a systemmap:Information ;
-    rdfs:label "Daten zur Milchsegmentierung"@de,
-        "Data on milk segmentation"@en,
-        "Données sur la segmentation du lait"@fr,
-        "Dati sulla segmentazione del latte"@it ;
-    rdfs:comment "Daten zur Segmentierung der Milchverwertung gemäss dem BOM1-Reglement."@de,
-        "Data on the segmentation of milk utilization according to the BOM1 regulation."@en,
-        "Données sur la segmentation de la valorisation du lait selon le règlement BOM1."@fr,
-        "Dati sulla segmentazione dell'utilizzo del latte secondo il regolamento BOM1."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
-
-systemmap:INF026 a systemmap:Information ;
-    rdfs:label "Milchstatistik"@de,
-        "Milk statistics"@en,
-        "Statistiques du lait"@fr,
-        "Statistiche del latte"@it ;
-    rdfs:comment "Monatliche Statistiken und Mehrjahresvergleiche, die Angaben über die produzierte Milch und deren Verarbeitung in verschiedene Produktgruppen enthalten."@de,
-        "Monthly statistics and multi-year comparisons containing information on the milk produced and its processing into different product groups."@en,
-        "Statistiques mensuelles et comparaisons pluriannuelles contenant des informations sur le lait produit et sa transformation en différentes catégories de produits."@fr,
-        "Statistiche mensili e confronti pluriennali contenenti informazioni sul latte prodotto e sulla sua trasformazione in diverse categorie di prodotti."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
-
-systemmap:INF028 a systemmap:Information ;
-    rdfs:label "Details zu Unternehmen"@de,
-        "Company details"@en,
-        "Détails sur les entreprises"@fr,
-        "Dettagli sulle imprese"@it ;
+systemmap:Q6ILF4g1j5sNf9aG a systemmap:PersonInformation ;
+    rdfs:label "Informationen zur Einfuhr von PSM"@de,
+        "Information on the import of PPP"@en,
+        "Informations sur l'importation de PPP"@fr,
+        "Informazioni sull'importazione di PPP"@it ;
     rdfs:comment """
-        Anzahl beschäftigte Personen nach Geschlecht und Arbeitszeit, Grundkapital der Aktiengesellschaften, Umsatzzahlen, Datum des Eintrags oder der Löschung im Handelsregister, Datum der Bekanntgabe der Gründung oder Schliessung eines Unternehmens oder Betriebs.
+        Informationen zum Einfuhrzeitpunkt, dem Produkt, dem Importeur und dem Empfänger eines Pflanzenschutzmittels (PSM).
         """@de,
         """
-        Number of employees by gender and working hours, share capital of joint-stock companies, revenue figures, date of registration or deletion in the commercial register, date of announcement of the establishment or closure of a company or business.
+        Information on the import date, the product, the importer, and the recipient of a plant protection product (PPP).
         """@en,
         """
-        Nombre d'employés selon le sexe et le temps de travail, capital social des sociétés anonymes, chiffres d'affaires, date d'inscription ou de suppression au registre du commerce, date d'annonce de la création ou de la fermeture d'une entreprise ou d'un établissement.
+        Informations sur la date d'importation, le produit, l'importateur et le destinataire d'un produit phytosanitaire (PPP).
         """@fr,
         """
-        Numero di dipendenti per genere e orario di lavoro, capitale sociale delle società per azioni, dati di fatturato, data di registrazione o cancellazione nel registro commerciale, data di annuncio della fondazione o chiusura di un'azienda o impresa.
+        Informazioni sulla data di importazione, il prodotto, l'importatore e il destinatario di un prodotto fitosanitario (PPP).
         """@it ;
-    systemmap:containedIn systemmap:SYS025 .
+    systemmap:containedIn systemmap:QywklUB91myTH0cvS ;
+    systemmap:informedBy systemmap:QfQ6BN8rDjKhTWL4 .
 
-systemmap:INF033 a systemmap:Information ;
-    rdfs:label "Produktekatalog"@de,
-        "Product catalog"@en,
-        "Catalogue de produits"@fr,
-        "Catalogo dei prodotti"@it ;
-    rdfs:comment """
-        Sammlung von Informationen zu Pflanzenschutzmittel-, Futtermittel-, Mineraldünger-, Hof- und Recyclingdünger-Produkten.
-        Das beinhaltet jeweilige Identifikatoren, Namen, Beschreibungen, Inhaltsstoffe und Mengen etc.
-        """@de,
-        """
-        Collection of information on plant protection products, feed, mineral fertilizers, farm and recycled fertilizers.
-        This includes respective identifiers, names, descriptions, ingredients, and quantities, etc.
-        """@en,
-        """
-        Collection d'informations sur les produits phytosanitaires, les aliments pour animaux, les engrais minéraux, les engrais de ferme et les engrais recyclés.
-        Cela inclut les identifiants respectifs, les noms, les descriptions, les ingrédients et les quantités, etc.
-        """@fr,
-        """
-        Raccolta di informazioni sui prodotti fitosanitari, i mangimi, i fertilizzanti minerali, i fertilizzanti agricoli e quelli riciclati.
-        Ciò include gli identificatori, i nomi, le descrizioni, gli ingredienti e le quantità, ecc.
-        """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF ;
-    systemmap:informedBy systemmap:INF037,
-        systemmap:INF042 .
-
-systemmap:INF034 a systemmap:Information ;
-    rdfs:label "Verschiebung von Hof- und Recyclingdünger"@de,
-        "Movement of Farmyard and Recycled Fertilizers"@en,
-        "Déplacement des engrais de ferme et recyclés"@fr,
-        "Spostamento dei fertilizzanti aziendali e riciclati"@it ;
-    rdfs:comment """
-        Die Verschiebung von Hof- und Recyclingdüngern umfasst die Erfassung und Meldung aller Zu- und Abgänge, einschliesslich Käufe, Verkäufe und betrieblicher Transfers.
-        """@de,
-        """
-        The movement of farmyard and recycled fertilizers includes the recording and reporting of all inflows and outflows, including purchases, sales, and internal transfers.
-        """@en,
-        """
-        Le déplacement des engrais de ferme et recyclés comprend l'enregistrement et la déclaration de toutes les entrées et sorties, y compris les achats, les ventes et les transferts internes.
-        """@fr,
-        """
-        Lo spostamento dei fertilizzanti aziendali e riciclati include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
-        """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
-
-systemmap:INF035 a systemmap:Information ;
-    rdfs:label "Verschiebung von Mineraldüngern"@de,
-        "Movement of Mineral Fertilizers"@en,
-        "Déplacement des engrais minéraux"@fr,
-        "Spostamento dei fertilizzanti minerali"@it ;
-    rdfs:comment """
-        Die Verschiebung von Mineraldüngern umfasst die Erfassung und Meldung aller Zu- und Abgänge mineralischer Düngemittel, einschliesslich Käufe, Verkäufe und betrieblicher Transfers.
-        """@de,
-        """
-        The movement of mineral fertilizers includes the recording and reporting of all inflows and outflows of mineral fertilizers, including purchases, sales, and internal transfers.
-        """@en,
-        """
-        Le déplacement des engrais minéraux comprend l'enregistrement et la déclaration de toutes les entrées et sorties d'engrais minéraux, y compris les achats, les ventes et les transferts internes.
-        """@fr,
-        """
-        Lo spostamento dei fertilizzanti minerali include la registrazione e la segnalazione di tutti gli afflussi e deflussi di fertilizzanti minerali, compresi acquisti, vendite e trasferimenti interni.
-        """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
-
-systemmap:INF036 a systemmap:Information ;
-    rdfs:label "Verschiebung von Pflanzenschutzmitteln"@de,
-        "Movement of Plant Protection Products"@en,
-        "Déplacement des produits phytosanitaires"@fr,
-        "Spostamento dei prodotti fitosanitari"@it ;
-    rdfs:comment """
-        Die Verschiebung von Pflanzenschutzmitteln umfasst die Erfassung und Meldung aller Zu- und Abgänge von Pflanzenschutzmitteln, einschliesslich Käufe, Verkäufe und betrieblicher Transfers.
-        """@de,
-        """
-        The movement of plant protection products includes the recording and reporting of all inflows and outflows, including purchases, sales, and internal transfers.
-        """@en,
-        """
-        Le déplacement des produits phytosanitaires comprend l'enregistrement et la déclaration de toutes les entrées et sorties, y compris les achats, les ventes et les transferts internes.
-        """@fr,
-        """
-        Lo spostamento dei prodotti fitosanitari include la registrazione e la segnalazione di tutti gli afflussi e deflussi, compresi acquisti, vendite e trasferimenti interni.
-        """@it ;
-    systemmap:containedIn systemmap:QjCVTMrYaOTygNcqF .
-
-systemmap:INF037 a systemmap:Information ;
-    rdfs:label "Pflanzenschutzmittel"@de,
-        "Plant Protection Products"@en,
-        "Produits phytosanitaires"@fr,
-        "Prodotti fitosanitari"@it ;
-    rdfs:comment """
-        Liste der in der Schweiz erlaubten Pflanzenschutzmittel, deren chemische Zusammensetzung, W-Nummern und Bewilligungsinhaber.
-        """@de,
-        """
-        List of plant protection products authorized in Switzerland, including their chemical composition, W-numbers, and authorization holders.
-        """@en,
-        """
-        Liste des produits phytosanitaires autorisés en Suisse, y compris leur composition chimique, numéros W et titulaires d'autorisation.
-        """@fr,
-        """
-        Elenco dei prodotti fitosanitari autorizzati in Svizzera, inclusa la loro composizione chimica, i numeri W e i titolari dell'autorizzazione.
-        """@it ;
-    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
-
-systemmap:INF038 a systemmap:Information ;
-    rdfs:label "Kulturen und Schaderreger"@de,
-        "Crops and Pests"@en,
-        "Cultures et organismes nuisibles"@fr,
-        "Colture e organismi nocivi"@it ;
-    rdfs:comment """
-        Liste der Kulturen und Schaderreger, für die in der Schweiz bereits eine Pflanzenschutzmittelbewilligung erteilt wurde.
-        """@de,
-        """
-        List of crops and pests for which a plant protection product authorization has already been granted in Switzerland.
-        """@en,
-        """
-        Liste des cultures et organismes nuisibles pour lesquels une autorisation de produit phytosanitaire a déjà été accordée en Suisse.
-        """@fr,
-        """
-        Elenco delle colture e degli organismi nocivi per i quali è già stata concessa un'autorizzazione per un prodotto fitosanitario in Svizzera.
-        """@it ;
-    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
-
-systemmap:INF039 a systemmap:Information ;
-    rdfs:label "Auflagen zur Anwendung von Pflanzenschutzmitteln"@de,
-        "Conditions for the Use of Plant Protection Products"@en,
-        "Conditions d'utilisation des produits phytosanitaires"@fr,
-        "Condizioni per l'uso dei prodotti fitosanitari"@it ;
-    rdfs:comment """
-        Bestimmungen und Einschränkungen, die bei der Anwendung von Pflanzenschutzmitteln zu beachten sind, einschliesslich Dosierung, Anwendungszeitpunkt und Schutzmassnahmen.
-        """@de,
-        """
-        Regulations and restrictions to be observed when using plant protection products, including dosage, application timing, and protective measures.
-        """@en,
-        """
-        Règlements et restrictions à respecter lors de l'utilisation de produits phytosanitaires, y compris le dosage, le moment de l'application et les mesures de protection.
-        """@fr,
-        """
-        Regolamenti e restrizioni da osservare nell'uso dei prodotti fitosanitari, inclusi dosaggio, tempistica dell'applicazione e misure protettive.
-        """@it ;
-    systemmap:containedIn systemmap:Qhhoiq8azX3SHGL3W .
-
-systemmap:INF040 a systemmap:Information ;
-    rdfs:label "Zubereitungen"@de,
-        "Preparations"@en,
-        "Préparations"@fr,
-        "Preparazioni"@it ;
-    rdfs:comment """
-        Mischungen oder Lösungen aus zwei oder mehr Stoffen.
-        """@de,
-        """
-        Mixtures or solutions composed of two or more substances.
-        """@en,
-        """
-        Mélanges ou solutions composés de deux ou plusieurs substances.
-        """@fr,
-        """
-        Miscele o soluzioni composte da due o più sostanze.
-        """@it ;
-    systemmap:containedIn systemmap:SYS028 .
-
-systemmap:INF041 a systemmap:Information ;
-    rdfs:label "Biozide"@de,
-        "Biocides"@en,
-        "Biocides"@fr,
-        "Biocidi"@it ;
-    rdfs:comment """
-        Produkte zur Bekämpfung von Schadorganismen. Mitenthalten sind auch parallel importierte Pflanzenschutzmittel, also solche, die aus anderen Ländern eingeführt werden.
-        """@de,
-        """
-        Products used to combat harmful organisms. This also includes parallel-imported plant protection products, meaning those imported from other countries.
-        """@en,
-        """
-        Produits utilisés pour lutter contre les organismes nuisibles. Cela inclut également les produits phytosanitaires importés en parallèle, c'est-à-dire en provenance d'autres pays.
-        """@fr,
-        """
-        Prodotti utilizzati per combattere gli organismi nocivi. Sono inclusi anche i prodotti fitosanitari importati parallelamente da altri paesi.
-        """@it ;
-    systemmap:containedIn systemmap:SYS028 .
-
-systemmap:INF042 a systemmap:Information ;
-    rdfs:label "Dünger"@de,
-        "Fertilizers"@en,
-        "Engrais"@fr,
-        "Fertilizzanti"@it ;
-    rdfs:comment """
-        Produkte zur Boden- und Pflanzendüngung.
-        """@de,
-        """
-        Products for soil and plant fertilization.
-        """@en,
-        """
-        Produits pour la fertilisation des sols et des plantes.
-        """@fr,
-        """
-        Prodotti per la fertilizzazione del suolo e delle piante.
-        """@it ;
-    systemmap:containedIn systemmap:SYS028 .
-
-systemmap:INF045 a systemmap:Information ;
-    rdfs:label "Agrarmarktdaten"@de,
-        "agricultural market data"@en,
-        "données du marché agricole"@fr,
-        "dati di mercato agricolo"@it ;
-    rdfs:comment "Marktdaten enthalten Preise, Mengen, Produktionssysteme."@de,
-        "Market data includes prices, quantities, production systems."@en,
-        "Les données de marché comprennent les prix, les quantités, les systèmes de production."@fr,
-        "I dati di mercato comprendono prezzi, quantità e sistemi di produzione."@it ;
-    systemmap:containedIn systemmap:SYS029 ;
-    systemmap:informs systemmap:INF046 .
-
-systemmap:INF046 a systemmap:Information ;
-    rdfs:label "Linked Data"@de,
-        "Linked Data"@en,
-        "Linked Data"@fr,
-        "Linked Data"@it ;
-    systemmap:containedIn systemmap:QHFSc6xgsHF70IlUd,
-        systemmap:QpLZd1ojPxF0CvH28 .
-
-systemmap:QLXw4VofhYbzXVNKC a systemmap:Information ;
-    rdfs:label "Daten zur Milchverwertung"@de,
-        "Data on milk utilization"@en,
-        "Données sur la valorisation du lait"@fr,
-        "Dati sull'utilizzo del latte"@it ;
-    rdfs:comment "Diese Daten sind essenziell für die Berechnung und Auszahlung von Zulagen für verkäste Milch sowie für die Fütterung ohne Silage durch das Bundesamt für Landwirtschaft (BLW)."@de,
-        "These data are essential for the calculation and payment of subsidies for cheesed milk as well as for feeding without silage by the Federal Office for Agriculture (BLW)."@en,
-        "Ces données sont essentielles pour le calcul et le paiement des subventions pour le lait transformé en fromage ainsi que pour l'alimentation sans ensilage par l'Office fédéral de l'agriculture (OFAG)."@fr,
-        "Questi dati sono essenziali per il calcolo e il pagamento dei sussidi per il latte trasformato in formaggio e per l'alimentazione senza insilato da parte dell'Ufficio federale dell'agricoltura (UFAG)."@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
-
-systemmap:Qe6Nt3cqogxz2d10g a systemmap:Information ;
-    rdfs:label "Daten zur Milchproduktion"@de,
-        "Data on milk production"@en,
-        "Données sur la production laitière"@fr,
-        "Dati sulla produzione di latte"@it ;
-    rdfs:comment """
-        Monatliche Produktionsmengen (in kg) der im Vormonat gelieferten Kuh- und Büffelmilch von allen Milchproduzenten.
-        Das BLW benötigt diese Information für die Ausrichtung der Zulage für Verkehrsmilch.
-        """@de,
-        """
-        Monthly production quantities (in kg) of cow and buffalo milk delivered in the previous month by all milk producers.
-        The BLW requires this information for the allocation of the subsidy for market milk.
-        """@en,
-        """
-        Quantités de production mensuelles (en kg) du lait de vache et de bufflonne livré le mois précédent par tous les producteurs de lait.
-        L'OFAG a besoin de ces informations pour l'octroi de la subvention pour le lait de consommation.
-        """@fr,
-        """
-        Quantità di produzione mensili (in kg) del latte di mucca e bufala consegnato nel mese precedente da tutti i produttori di latte.
-        L'UFAG necessita di queste informazioni per l'assegnazione del sussidio per il latte di consumo.
-        """@it ;
-    systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
-
-systemmap:INF001 a systemmap:PersonInformation ;
+systemmap:Q6aBblr7qNp15tGw a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Bewirtschaftenden"@de,
         "Contact details of farm managers"@en,
         "Coordonnées des exploitants agricoles"@fr,
@@ -2717,19 +2737,7 @@ systemmap:INF001 a systemmap:PersonInformation ;
         "Informazioni sui dati di contatto dei gestori agricoli, come indirizzi e-mail o numeri di telefono."@it ;
     systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
-systemmap:INF002 a systemmap:PersonInformation ;
-    rdfs:label "Informationen der Strukturdatenerhebung"@de,
-        "Information from the structural data survey"@en,
-        "Informations de l'enquête sur les données structurelles"@fr,
-        "Informazioni dall'indagine sui dati strutturali"@it ;
-    systemmap:containedIn systemmap:QMjqlEoVCR9wpTyN1,
-        systemmap:QPWOFHR512FuAc25b,
-        systemmap:QZ9LRAuSt2EOvBpqY,
-        systemmap:QmWEQ8lVlDS9ZwPkY,
-        systemmap:QpR2aDraNmiUXz55J ;
-    systemmap:informs systemmap:INF015 .
-
-systemmap:INF011 a systemmap:PersonInformation ;
+systemmap:QJuklUVKfEwj2Xpc a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Züchter"@de,
         "Contact details of breeders"@en,
         "Coordonnées des sélectionneurs"@fr,
@@ -2740,21 +2748,7 @@ systemmap:INF011 a systemmap:PersonInformation ;
         "Dati di contatto dei selezionatori che forniscono informazioni sulle varietà a ProVar."@it ;
     systemmap:containedIn systemmap:QE5DY78J7vgfoiDLj .
 
-systemmap:INF014 a systemmap:PersonInformation ;
-    rdfs:label "Betriebsdaten (Person, Betrieb)"@de,
-        "Operational data (Person, Business)"@en,
-        "Données opérationnelles (Personne, Entreprise)"@fr,
-        "Dati operativi (Persona, Impresa)"@it ;
-    rdfs:comment "Enthält grundlegende Informationen zu landwirtschaftlichen Betrieben sowie zu den zugehörigen Personen. Dazu gehören Identifikationsdaten, organisatorische Strukturen und Angaben zu den am Betrieb beteiligten Personen (z. B. Betriebsleiter, Familienmitglieder und Mitarbeitende)."@de,
-        "Contains basic information about agricultural businesses and related individuals. This includes identification data, organizational structures, and details about individuals involved in the business (e.g., farm managers, family members, and employees)."@en,
-        "Contient des informations de base sur les exploitations agricoles et les personnes associées. Cela inclut les données d'identification, les structures organisationnelles et les détails sur les personnes impliquées dans l'exploitation (p. ex. gestionnaires de ferme, membres de la famille et employés)."@fr,
-        "Contiene informazioni di base sulle aziende agricole e sulle persone ad esse associate. Ciò include dati identificativi, strutture organizzative e dettagli sulle persone coinvolte nell'azienda (ad es. gestori dell'azienda, familiari e dipendenti)."@it ;
-    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
-    systemmap:informs systemmap:INF030 ;
-    systemmap:usesIdentifier systemmap:INF003,
-        systemmap:INF004 .
-
-systemmap:INF016 a systemmap:PersonInformation ;
+systemmap:QQ2MIhpz1CvdqK6f a systemmap:PersonInformation ;
     rdfs:label "Beitragsdaten"@de,
         "Contribution data"@en,
         "Données de contribution"@fr,
@@ -2777,7 +2771,78 @@ systemmap:INF016 a systemmap:PersonInformation ;
         """@it ;
     systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
-systemmap:INF018 a systemmap:PersonInformation ;
+systemmap:QX1qchbxSZKWI6Up a systemmap:PersonInformation ;
+    rdfs:label "Informationen zu Landwirtschaftsbetrieben"@de,
+        "Information about agricultural enterprises"@en,
+        "Informations sur les exploitations agricoles"@fr,
+        "Informazioni sulle aziende agricole"@it ;
+    rdfs:comment "Zahl der Grossvieheinheiten, Angaben über die Bodennutzung, den Beruf und das Alter des Betriebsleiters/der Betriebsleiterin."@de,
+        "Number of large livestock units, information on land use, occupation and age of the farm manager."@en,
+        "Nombre d'unités de gros bétail, informations sur l'utilisation des sols, la profession et l'âge du directeur ou de la directrice d'exploitation."@fr,
+        "Numero di unità di bestiame grosso, informazioni sull'uso del suolo, la professione e l'età del gestore aziendale."@it ;
+    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+
+systemmap:QY9n2yTOBWXtZ6se a systemmap:PersonInformation ;
+    rdfs:label "Daten über Kontrollen und Kontrollergebnisse"@de,
+        "Data on inspections and inspection results"@en,
+        "Données sur les contrôles et les résultats des contrôles"@fr,
+        "Dati sui controlli e sui risultati dei controlli"@it ;
+    systemmap:containedIn systemmap:Q9VcxLSoIIwQjoexY .
+
+systemmap:QYlOxcohgWiXr61M a systemmap:PersonInformation ;
+    rdfs:label "Informationen zu Forstbetrieben"@de,
+        "Information about forestry enterprises"@en,
+        "Informations sur les entreprises forestières"@fr,
+        "Informazioni sulle aziende forestali"@it ;
+    rdfs:comment "Anzahl beschäftigte Personen nach Geschlecht und Arbeitszeit."@de,
+        "Number of employed persons by gender and working time."@en,
+        "Nombre de personnes employées selon le sexe et le temps de travail."@fr,
+        "Numero di persone impiegate per genere e orario di lavoro."@it ;
+    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+
+systemmap:QakCt52w8AKrsSXi a systemmap:PersonInformation ;
+    rdfs:label "Informationen der Strukturdatenerhebung"@de,
+        "Information from the structural data survey"@en,
+        "Informations de l'enquête sur les données structurelles"@fr,
+        "Informazioni dall'indagine sui dati strutturali"@it ;
+    systemmap:containedIn systemmap:QMjqlEoVCR9wpTyN1,
+        systemmap:QPWOFHR512FuAc25b,
+        systemmap:QZ9LRAuSt2EOvBpqY,
+        systemmap:QmWEQ8lVlDS9ZwPkY,
+        systemmap:QpR2aDraNmiUXz55J ;
+    systemmap:informs systemmap:QzuDlnYUQMk3HaCb .
+
+systemmap:QeUFazO70bpqCYJ5 a systemmap:PersonInformation ;
+    rdfs:label "Stammdaten und Identifikatoren"@de,
+        "Master data and identifiers"@en,
+        "Données de base et identifiants"@fr,
+        "Dati di base e identificatori"@it ;
+    rdfs:comment "Name und Adresse des Unternehmens oder Betriebs, Gemeindenummern, BUR-Nummer (nichtsprechende 8-stellige Identifikationsnummer), Unternehmens-Identifikationsnummer (UID), Art der wirtschaftlichen Tätigkeit (NOGA), Rechtsform des Unternehmens."@de,
+        "Name and address of the company or business, municipality numbers, BUR number (non-speaking 8-digit identification number), company identification number (UID), type of economic activity (NOGA), legal form of the company."@en,
+        "Nom et adresse de l'entreprise ou de l'exploitation, numéros de commune, numéro BUR (numéro d'identification à 8 chiffres non parlant), numéro d'identification de l'entreprise (UID), type d'activité économique (NOGA), forme juridique de l'entreprise."@fr,
+        "Nome e indirizzo dell'azienda o dell'impresa, numeri dei comuni, numero BUR (numero di identificazione a 8 cifre non parlante), numero di identificazione aziendale (UID), tipo di attività economica (NOGA), forma giuridica dell'azienda."@it ;
+    systemmap:containedIn systemmap:QHyBeGX0LsQwjJ6Z .
+
+systemmap:QfQ6BN8rDjKhTWL4 a systemmap:PersonInformation ;
+    rdfs:label "Pflanzenschutzmittel-Importe"@de,
+        "Pesticide imports"@en,
+        "Importations de produits phytosanitaires"@fr,
+        "Importazioni di prodotti fitosanitari"@it ;
+    rdfs:comment """
+        Daten zu jedem Import von Pflanzenschutzmitteln mit UID und Namen des Importeurs, Datum des Imports, Importmenge, Warenbezeichnung (Freitext) sowie Zustelladresse.
+        """@de,
+        """
+        Data on each import of pesticides, including UID and name of the importer, date of import, import quantity, product designation (free text), and delivery address.
+        """@en,
+        """
+        Données sur chaque importation de produits phytosanitaires, y compris l'UID et le nom de l'importateur, la date d'importation, la quantité importée, la désignation du produit (texte libre) et l'adresse de livraison.
+        """@fr,
+        """
+        Dati su ogni importazione di prodotti fitosanitari, compresi UID e nome dell'importatore, data di importazione, quantità importata, denominazione del prodotto (testo libero) e indirizzo di consegna.
+        """@it ;
+    systemmap:containedIn systemmap:Q7u1Bh6qfXUbSDkv .
+
+systemmap:QldiTYOuXQmoC3SV a systemmap:PersonInformation ;
     rdfs:label "Anmeldungen für Direktzahlungsarten"@de,
         "Registrations for direct payment types"@en,
         "Inscriptions pour les types de paiements directs"@fr,
@@ -2800,85 +2865,6 @@ systemmap:INF018 a systemmap:PersonInformation ;
         """@it ;
     systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
-systemmap:INF027 a systemmap:PersonInformation ;
-    rdfs:label "Stammdaten und Identifikatoren"@de,
-        "Master data and identifiers"@en,
-        "Données de base et identifiants"@fr,
-        "Dati di base e identificatori"@it ;
-    rdfs:comment "Name und Adresse des Unternehmens oder Betriebs, Gemeindenummern, BUR-Nummer (nichtsprechende 8-stellige Identifikationsnummer), Unternehmens-Identifikationsnummer (UID), Art der wirtschaftlichen Tätigkeit (NOGA), Rechtsform des Unternehmens."@de,
-        "Name and address of the company or business, municipality numbers, BUR number (non-speaking 8-digit identification number), company identification number (UID), type of economic activity (NOGA), legal form of the company."@en,
-        "Nom et adresse de l'entreprise ou de l'exploitation, numéros de commune, numéro BUR (numéro d'identification à 8 chiffres non parlant), numéro d'identification de l'entreprise (UID), type d'activité économique (NOGA), forme juridique de l'entreprise."@fr,
-        "Nome e indirizzo dell'azienda o dell'impresa, numeri dei comuni, numero BUR (numero di identificazione a 8 cifre non parlante), numero di identificazione aziendale (UID), tipo di attività economica (NOGA), forma giuridica dell'azienda."@it ;
-    systemmap:containedIn systemmap:SYS025 .
-
-systemmap:INF029 a systemmap:PersonInformation ;
-    rdfs:label "Informationen zu Forstbetrieben"@de,
-        "Information about forestry enterprises"@en,
-        "Informations sur les entreprises forestières"@fr,
-        "Informazioni sulle aziende forestali"@it ;
-    rdfs:comment "Anzahl beschäftigte Personen nach Geschlecht und Arbeitszeit."@de,
-        "Number of employed persons by gender and working time."@en,
-        "Nombre de personnes employées selon le sexe et le temps de travail."@fr,
-        "Numero di persone impiegate per genere e orario di lavoro."@it ;
-    systemmap:containedIn systemmap:SYS025 .
-
-systemmap:INF030 a systemmap:PersonInformation ;
-    rdfs:label "Informationen zu Landwirtschaftsbetrieben"@de,
-        "Information about agricultural enterprises"@en,
-        "Informations sur les exploitations agricoles"@fr,
-        "Informazioni sulle aziende agricole"@it ;
-    rdfs:comment "Zahl der Grossvieheinheiten, Angaben über die Bodennutzung, den Beruf und das Alter des Betriebsleiters/der Betriebsleiterin."@de,
-        "Number of large livestock units, information on land use, occupation and age of the farm manager."@en,
-        "Nombre d'unités de gros bétail, informations sur l'utilisation des sols, la profession et l'âge du directeur ou de la directrice d'exploitation."@fr,
-        "Numero di unità di bestiame grosso, informazioni sull'uso del suolo, la professione e l'età del gestore aziendale."@it ;
-    systemmap:containedIn systemmap:SYS025 .
-
-systemmap:INF031 a systemmap:PersonInformation ;
-    rdfs:label "Pflanzenschutzmittel-Importe"@de,
-        "Pesticide imports"@en,
-        "Importations de produits phytosanitaires"@fr,
-        "Importazioni di prodotti fitosanitari"@it ;
-    rdfs:comment """
-        Daten zu jedem Import von Pflanzenschutzmitteln mit UID und Namen des Importeurs, Datum des Imports, Importmenge, Warenbezeichnung (Freitext) sowie Zustelladresse.
-        """@de,
-        """
-        Data on each import of pesticides, including UID and name of the importer, date of import, import quantity, product designation (free text), and delivery address.
-        """@en,
-        """
-        Données sur chaque importation de produits phytosanitaires, y compris l'UID et le nom de l'importateur, la date d'importation, la quantité importée, la désignation du produit (texte libre) et l'adresse de livraison.
-        """@fr,
-        """
-        Dati su ogni importazione di prodotti fitosanitari, compresi UID e nome dell'importatore, data di importazione, quantità importata, denominazione del prodotto (testo libero) e indirizzo di consegna.
-        """@it ;
-    systemmap:containedIn systemmap:SYS026 .
-
-systemmap:INF032 a systemmap:PersonInformation ;
-    rdfs:label "Informationen zur Einfuhr von PSM"@de,
-        "Information on the import of PPP"@en,
-        "Informations sur l'importation de PPP"@fr,
-        "Informazioni sull'importazione di PPP"@it ;
-    rdfs:comment """
-        Informationen zum Einfuhrzeitpunkt, dem Produkt, dem Importeur und dem Empfänger eines Pflanzenschutzmittels (PSM).
-        """@de,
-        """
-        Information on the import date, the product, the importer, and the recipient of a plant protection product (PPP).
-        """@en,
-        """
-        Informations sur la date d'importation, le produit, l'importateur et le destinataire d'un produit phytosanitaire (PPP).
-        """@fr,
-        """
-        Informazioni sulla data di importazione, il prodotto, l'importatore e il destinatario di un prodotto fitosanitario (PPP).
-        """@it ;
-    systemmap:containedIn systemmap:QywklUB91myTH0cvS ;
-    systemmap:informedBy systemmap:INF031 .
-
-systemmap:INF043 a systemmap:PersonInformation ;
-    rdfs:label "Daten über Kontrollen und Kontrollergebnisse"@de,
-        "Data on inspections and inspection results"@en,
-        "Données sur les contrôles et les résultats des contrôles"@fr,
-        "Dati sui controlli e sui risultati dei controlli"@it ;
-    systemmap:containedIn systemmap:Q9VcxLSoIIwQjoexY .
-
 systemmap:QoY82Q0qEk9k0s3w3 a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Milchproduzenten"@de,
         "Contact details of milk producers"@en,
@@ -2889,7 +2875,7 @@ systemmap:QoY82Q0qEk9k0s3w3 a systemmap:PersonInformation ;
         "Coordonnées des producteurs de lait, telles que les adresses, le numéro TVD, le numéro AGIS de l'exploitation, le numéro AGIS de l'exploitant et les informations de paiement pour la subvention pour le lait transformé en fromage et la subvention pour l'alimentation sans ensilage. Si possible, ces coordonnées sont obtenues auprès d'AGIS."@fr,
         "Dati di contatto dei produttori di latte, come indirizzi, numero TVD, numero AGIS dell'azienda, numero AGIS del gestore e informazioni di pagamento per il sussidio per il latte trasformato in formaggio e il sussidio per l'alimentazione senza insilato. Se possibile, questi dati di contatto vengono ottenuti da AGIS."@it ;
     systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP ;
-    systemmap:informedBy systemmap:INF001 .
+    systemmap:informedBy systemmap:Q6aBblr7qNp15tGw .
 
 systemmap:Qutd0KIj3Rf8GlSwq a systemmap:PersonInformation ;
     rdfs:label "Kontaktdaten Milchverarbeiter"@de,
@@ -2901,6 +2887,20 @@ systemmap:Qutd0KIj3Rf8GlSwq a systemmap:PersonInformation ;
         "Coordonnées des transformateurs de lait, telles que les adresses ou les numéros d'identification."@fr,
         "Dati di contatto dei trasformatori di latte, come indirizzi o numeri di identificazione."@it ;
     systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
+
+systemmap:QvNriWslaOR5xkdw a systemmap:PersonInformation ;
+    rdfs:label "Betriebsdaten (Person, Betrieb)"@de,
+        "Operational data (Person, Business)"@en,
+        "Données opérationnelles (Personne, Entreprise)"@fr,
+        "Dati operativi (Persona, Impresa)"@it ;
+    rdfs:comment "Enthält grundlegende Informationen zu landwirtschaftlichen Betrieben sowie zu den zugehörigen Personen. Dazu gehören Identifikationsdaten, organisatorische Strukturen und Angaben zu den am Betrieb beteiligten Personen (z. B. Betriebsleiter, Familienmitglieder und Mitarbeitende)."@de,
+        "Contains basic information about agricultural businesses and related individuals. This includes identification data, organizational structures, and details about individuals involved in the business (e.g., farm managers, family members, and employees)."@en,
+        "Contient des informations de base sur les exploitations agricoles et les personnes associées. Cela inclut les données d'identification, les structures organisationnelles et les détails sur les personnes impliquées dans l'exploitation (p. ex. gestionnaires de ferme, membres de la famille et employés)."@fr,
+        "Contiene informazioni di base sulle aziende agricole e sulle persone ad esse associate. Ciò include dati identificativi, strutture organizzative e dettagli sulle persone coinvolte nell'azienda (ad es. gestori dell'azienda, familiari e dipendenti)."@it ;
+    systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k ;
+    systemmap:informs systemmap:QX1qchbxSZKWI6Up ;
+    systemmap:usesIdentifier systemmap:Q3jZwzvmFKsXRWiI,
+        systemmap:QDLEUPczkJ9AWZeC .
 
 systemmap:QDetpcQhSMo4IAeAb a systemmap:PrivateOrganization ;
     rdfs:label "Barto AG"@de,
@@ -3065,7 +3065,7 @@ zefix:787227 a systemmap:PrivateOrganization ;
     rdfs:label "RAMSEIER Suisse AG"@de ;
     systemmap:ownedBy systemmap:QFAcWHo27bji7sVts .
 
-systemmap:INF017 a systemmap:SensitivePersonInformation ;
+systemmap:QDqb9NPoB6n3MZf2 a systemmap:SensitivePersonInformation ;
     rdfs:label "Kürzungen von Direktzahlungen"@de,
         "Reductions in direct payments"@en,
         "Réductions des paiements directs"@fr,
@@ -3088,7 +3088,7 @@ systemmap:INF017 a systemmap:SensitivePersonInformation ;
         """@it ;
     systemmap:containedIn systemmap:QvDlxaJ5YMkuZGH6k .
 
-systemmap:INF024 a systemmap:SensitivePersonInformation ;
+systemmap:QLvuxq7SeZ6X0GYA a systemmap:SensitivePersonInformation ;
     rdfs:label "Resultate der Milchprüfung"@de,
         "Results of milk testing"@en,
         "Résultats du contrôle du lait"@fr,
@@ -3118,7 +3118,7 @@ systemmap:INF024 a systemmap:SensitivePersonInformation ;
         """@it ;
     systemmap:containedIn systemmap:QYOd1TkacTh6cr0xP .
 
-systemmap:INF044 a systemmap:SensitivePersonInformation ;
+systemmap:QfXioR1gkj8eDuTF a systemmap:SensitivePersonInformation ;
     rdfs:label "Daten über Verwaltungsmassnahmen und strafrechtliche Sanktionen"@de,
         "Data on administrative measures and criminal sanctions"@en,
         "Données sur les mesures administratives et les sanctions pénales"@fr,


### PR DESCRIPTION
New use of IRIs:

- `zefix:` organizations are directly used for private organizations *if* they do not have a custom description within the system map. Example: <https://register.ld.admin.ch/zefix/company/787227> (Note: Some attributes on this page are assigned by the system map.)
- All system-map instances were assigned new, non speaking nano identifiers (16-digit complete random alphanumerical strings, but they all start with Q.)
- New nano ids can be generated here: <https://blw-ofag-ufag.github.io/system-map/nanoid>, or with:

```r
nano <- function(length = 16, start = "S") {
  paste(c(start, sample(c(LETTERS, letters, 0:9), size = length - nchar(start))), collapse = "")
}
```