### PR TITLE
Include LINDAS metadata for the dataset #54

### DIFF
--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -22,6 +22,7 @@ systemmap:metadata a void:Dataset ;
     schema:dateModified "2025-04-09"^^xsd:date ;
     schema:datePublished "2025-02-24"^^xsd:date ;
     schema:workExample <https://blw-ofag-ufag.github.io/system-map> ;
+    rdfs:seeAlso <https://github.com/blw-ofag-ufag/metadata/blob/main/data/raw/datasets/83f93ff4-ef3f-43f1-af2c-83f18952283e.json> ;
     rdfs:comment """
         Eine Sammlung von Organisationen, Informationssystemen und Informationseinheiten (Daten) im Schweizer Agrar- und Lebensmittelsektor.
         """@de,

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -1,7 +1,6 @@
 @prefix LwG: <https://www.fedlex.admin.ch/eli/cc/1998/3033_3033_3033#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix ns1: <http://schema.org/schema:> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <http://schema.org/> .
@@ -19,9 +18,10 @@ systemmap:metadata a void:Dataset ;
     void:sparqlEndpoint <https://register.ld.admin.ch/query/> ;
     schema:contactPoint staatskalender:10008654 ;
     schema:creator staatskalender:10008654 ;
+    schema:dateCreated "2025-01-29"^^xsd:date ;
     schema:dateModified "2025-04-09"^^xsd:date ;
     schema:datePublished "2025-02-24"^^xsd:date ;
-    ns1:dateCreated "2025-01-29"^^xsd:date ;
+    schema:workExample <https://blw-ofag-ufag.github.io/system-map> ;
     rdfs:comment """
         Eine Sammlung von Organisationen, Informationssystemen und Informationseinheiten (Daten) im Schweizer Agrar- und Lebensmittelsektor.
         """@de,

--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -1,10 +1,40 @@
 @prefix LwG: <https://www.fedlex.admin.ch/eli/cc/1998/3033_3033_3033#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ns1: <http://schema.org/schema:> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <http://schema.org/> .
 @prefix staatskalender: <https://register.ld.admin.ch/staatskalender/organization/> .
 @prefix systemmap: <https://agriculture.ld.admin.ch/system-map/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+systemmap:metadata a void:Dataset ;
+    rdfs:label "DigiAgriFoodCH Systemlandkarte"@de,
+        "DigiAgriFoodCH System Map"@en,
+        "Carte du système DigiAgriFoodCH"@fr,
+        "Mappa del sistema DigiAgriFoodCH"@it ;
+    dcterms:accrualPeriodicity <https://publications.europa.eu/resource/authority/frequency/IRREG> ;
+    void:sparqlEndpoint <https://register.ld.admin.ch/query/> ;
+    schema:contactPoint staatskalender:10008654 ;
+    schema:creator staatskalender:10008654 ;
+    schema:dateModified "2025-04-09"^^xsd:date ;
+    schema:datePublished "2025-02-24"^^xsd:date ;
+    ns1:dateCreated "2025-01-29"^^xsd:date ;
+    rdfs:comment """
+        Eine Sammlung von Organisationen, Informationssystemen und Informationseinheiten (Daten) im Schweizer Agrar- und Lebensmittelsektor.
+        """@de,
+        """
+        A collection of organizations, information systems and information units (data) in the Swiss agri-food sector.
+        """@en,
+        """
+        Une collection d’organisations, de systèmes d’information et d’unités d’information (données) dans le secteur agroalimentaire suisse.
+        """@fr,
+        """
+        Una raccolta di organizzazioni, sistemi informativi e unità informative (dati) nel settore agroalimentare svizzero.
+        """@it ;
+    dcat:landingPage <https://github.com/blw-ofag-ufag/system-map> .
 
 <https://www.fedlex.admin.ch/eli/cc/1986/926_926_926> a schema:Legislation ;
     rdfs:label "Bundesgesetz über die landwirtschaftliche Pacht"@de .

--- a/rdf/ontology.ttl
+++ b/rdf/ontology.ttl
@@ -740,7 +740,11 @@ systemmap:usesIdentifier a owl:ObjectProperty ;
     rdfs:range systemmap:Identifier .
 
 systemmap: a owl:Ontology ;
-    dcterms:creator "Federal Office for Agriculture" ;
+    rdfs:label "Ontologie der DigiAgriFoodCH Systemlandkarte"@de,
+        "DigiAgriFoodCH System Map Ontology"@en,
+        "Ontologie de la carte du système DigiAgriFoodCH"@fr,
+        "Ontologia della mappa del sistema DigiAgriFoodCH"@it ;
+    dcterms:creator "Federal Office for Agriculture"@en ;
     dcterms:description """
         Eine Ontologie zur Modellierung von Organisationen, IT-Systemen und Daten für das Schweizer Bundesamt für Landwirtschaft (FOAG).
         """@de,
@@ -753,9 +757,9 @@ systemmap: a owl:Ontology ;
         """
         Un'ontologia per modellare le organizzazioni, i sistemi IT e i dati per l'Ufficio federale dell'agricoltura (UFAG) svizzero.
         """@it ;
-    dcterms:title "DigiAgriFoodCH Systemlandkarte"@de,
-        "DigiAgriFoodCH System Map"@en,
-        "Carte du système DigiAgriFoodCH"@fr,
-        "Mappa del sistema DigiAgriFoodCH"@it ;
+    dcterms:title "Ontologie der DigiAgriFoodCH Systemlandkarte"@de,
+        "DigiAgriFoodCH System Map Ontology"@en,
+        "Ontologie de la carte du système DigiAgriFoodCH"@fr,
+        "Ontologia della mappa del sistema DigiAgriFoodCH"@it ;
     owl:versionInfo "0.3.0" .
 


### PR DESCRIPTION
# Description

The DigiAgriFoodCH system map metadata is described under <https://agriculture.ld.admin.ch/system-map/metadata>

# To do

- [x] Include all metadata relevant for the LINDAS query
- [x] Include all metadata relevant for opendata.swiss