### PR TITLE
101 better handling of translations

### DIFF
--- a/docs/config.js
+++ b/docs/config.js
@@ -20,6 +20,7 @@ const APP_CONFIG = {
         en: {
             appTitle: "FOAG System Map",
             settings: "Settings",
+            minDegree: "Minimum Node Connections",
             visibleNodeClasses: "Visible Node Classes",
             visibleRelationshipTypes: "Visible Relationship Types",
             cancel: "Cancel",
@@ -35,6 +36,7 @@ const APP_CONFIG = {
         de: {
             appTitle: "Systemkarte BLW",
             settings: "Einstellungen",
+            minDegree: "Minimale Anzahl Verbindungen",
             visibleNodeClasses: "Sichtbare Knotentypen",
             visibleRelationshipTypes: "Sichtbare Beziehungstypen",
             cancel: "Abbrechen",
@@ -50,6 +52,7 @@ const APP_CONFIG = {
         fr: {
             appTitle: "Carte des systèmes OFAG",
             settings: "Paramètres",
+            minDegree: "Nombre de connexions de nœuds minimum",
             visibleNodeClasses: "Classes de nœuds visibles",
             visibleRelationshipTypes: "Types de relations visibles",
             cancel: "Annuler",
@@ -65,6 +68,7 @@ const APP_CONFIG = {
         it: {
             appTitle: "Mappa dei sistemi UFAG",
             settings: "Impostazioni",
+            minDegree: "Numero minimo di connessioni dei nodi",
             visibleNodeClasses: "Classi di nodi visibili",
             visibleRelationshipTypes: "Tipi di relazioni visibili",
             cancel: "Annulla",

--- a/docs/config.js
+++ b/docs/config.js
@@ -67,6 +67,11 @@ const APP_CONFIG = {
      * This should be called once the DOM is ready.
      */
     initializeStylesFromCSS: function() {
+        // Create a reverse map from group name to IRI for easy lookup
+        this.GROUP_IRI_MAP = Object.fromEntries(
+            Object.entries(this.GROUP_MAP).map(([iri, group]) => [group, iri])
+        );
+
         this.GROUP_STYLES = {
             System: {
                 background: getCssVar('--color-group-system-bg'),

--- a/docs/config.js
+++ b/docs/config.js
@@ -15,6 +15,70 @@ const APP_CONFIG = {
     // SPARQL Endpoint for fetching data
     ENDPOINT: "https://lindas.admin.ch/query",
 
+    // User-facing text for translation
+    UI_TEXT: {
+        en: {
+            appTitle: "FOAG System Map",
+            settings: "Settings",
+            visibleNodeClasses: "Visible Node Classes",
+            visibleRelationshipTypes: "Visible Relationship Types",
+            cancel: "Cancel",
+            saveAndReload: "Save & Reload",
+            searchPlaceholder: "Search...",
+            settingsTooltip: "Settings",
+            githubTooltip: "GitHub",
+            emailTooltip: "Email",
+            errorLoading: "Error loading data",
+            fallbackSystemMapTitle: "System Map",
+            noLabel: "No label"
+        },
+        de: {
+            appTitle: "Systemkarte BLW",
+            settings: "Einstellungen",
+            visibleNodeClasses: "Sichtbare Knotentypen",
+            visibleRelationshipTypes: "Sichtbare Beziehungstypen",
+            cancel: "Abbrechen",
+            saveAndReload: "Speichern & neu laden",
+            searchPlaceholder: "Suchen...",
+            settingsTooltip: "Einstellungen",
+            githubTooltip: "GitHub",
+            emailTooltip: "E-Mail",
+            errorLoading: "Fehler beim Laden der Daten",
+            fallbackSystemMapTitle: "Systemkarte",
+            noLabel: "Ohne Bezeichnung"
+        },
+        fr: {
+            appTitle: "Carte des systèmes OFAG",
+            settings: "Paramètres",
+            visibleNodeClasses: "Classes de nœuds visibles",
+            visibleRelationshipTypes: "Types de relations visibles",
+            cancel: "Annuler",
+            saveAndReload: "Enregistrer & recharger",
+            searchPlaceholder: "Rechercher...",
+            settingsTooltip: "Paramètres",
+            githubTooltip: "GitHub",
+            emailTooltip: "E-mail",
+            errorLoading: "Erreur de chargement des données",
+            fallbackSystemMapTitle: "Carte du système",
+            noLabel: "Sans étiquette"
+        },
+        it: {
+            appTitle: "Mappa dei sistemi UFAG",
+            settings: "Impostazioni",
+            visibleNodeClasses: "Classi di nodi visibili",
+            visibleRelationshipTypes: "Tipi di relazioni visibili",
+            cancel: "Annulla",
+            saveAndReload: "Salva e ricarica",
+            searchPlaceholder: "Cerca...",
+            settingsTooltip: "Impostazioni",
+            githubTooltip: "GitHub",
+            emailTooltip: "E-mail",
+            errorLoading: "Errore nel caricamento dei dati",
+            fallbackSystemMapTitle: "Mappa del sistema",
+            noLabel: "Senza etichetta"
+        }
+    },
+
     // Prefixes for shortening IRIs into CURIEs
     PREFIXES: {
         "http://www.w3.org/2000/01/rdf-schema#": "rdfs",

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,28 +24,15 @@
   <!-- Settings pop-up structure -->
   <div id="settings-overlay" class="hidden">
     <div id="settings-panel">
-      <h2>Settings</h2>
+      <h2 id="settings-title"></h2>
 
       <!-- Two-column layout container -->
       <div class="settings-columns">
         
-        <!-- Column 1: General & Classes -->
+        <!-- Column 1: Classes -->
         <div class="settings-column">
           <div class="settings-section">
-            <h3>General</h3>
-            <!-- UPDATED: Focus Mode now uses the standard list item structure -->
-            <div class="settings-list-item">
-                <div class="settings-list-item-content">
-                    <label>
-                        <input type="checkbox" id="settingsFocusMode">
-                        <strong>Focus Mode (hides Info Panel)</strong>
-                    </label>
-                </div>
-            </div>
-          </div>
-
-          <div class="settings-section">
-            <h3>Visible Node Classes</h3>
+            <h3 id="settings-node-classes-title"></h3>
             <div id="settings-classes">
               <!-- This will be dynamically populated by main.js -->
             </div>
@@ -55,7 +42,7 @@
         <!-- Column 2: Predicates -->
         <div class="settings-column">
           <div class="settings-section">
-            <h3>Visible Relationship Types</h3>
+            <h3 id="settings-relationship-types-title"></h3>
             <div id="settings-predicates">
               <!-- This will be dynamically populated by main.js -->
             </div>
@@ -66,8 +53,8 @@
 
       <!-- Action buttons remain at the bottom -->
       <div class="settings-actions">
-        <button id="settingsCancel">Cancel</button>
-        <button id="settingsSave">Save & Reload</button>
+        <button id="settingsCancel"></button>
+        <button id="settingsSave"></button>
       </div>
     </div>
   </div>
@@ -86,15 +73,15 @@
   <div class="social-icons">
     <div class="search-container">
       <i class="fas fa-search"></i>
-      <input type="text" id="search-box" placeholder="Search...">
+      <input type="text" id="search-box">
     </div>
-    <a href="#" id="settings-trigger" title="Settings">
+    <a href="#" id="settings-trigger">
         <i class="fas fa-cog"></i>
     </a>
-    <a href="https://github.com/blw-ofag-ufag/system-map" target="_blank" title="GitHub">
+    <a href="https://github.com/blw-ofag-ufag/system-map" target="_blank" id="github-link">
       <i class="fab fa-github"></i>
     </a>
-    <a href="mailto:kompetenzzentrumdigitaletransformation@blw.admin.ch?subject=Systemlandkarte%20DigiAgriFoodCH" title="Email">
+    <a href="mailto:kompetenzzentrumdigitaletransformation@blw.admin.ch?subject=Systemlandkarte%20DigiAgriFoodCH" id="email-link">
       <i class="fas fa-envelope"></i>
     </a>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,15 +34,6 @@
           <div class="settings-section">
             <h3>General</h3>
             <div class="settings-item">
-              <label for="settingsLanguage">Language</label>
-              <select id="settingsLanguage">
-                <option value="de">Deutsch</option>
-                <option value="fr">Français</option>
-                <option value="it">Italiano</option>
-                <option value="en">English</option>
-              </select>
-            </div>
-            <div class="settings-item">
               <label for="settingsFocusMode">Focus Mode (hides Info Panel)</label>
               <input type="checkbox" id="settingsFocusMode" />
             </div>
@@ -76,6 +67,15 @@
     </div>
   </div>
 
+  <!-- New language selector container -->
+  <div class="language-selector-container">
+    <select id="languageSelector">
+      <option value="de">Deutsch</option>
+      <option value="fr">Français</option>
+      <option value="it">Italiano</option>
+      <option value="en">English</option>
+    </select>
+  </div>
 
   <!-- Icons container with new search box -->
   <div class="social-icons">

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,8 +29,16 @@
       <!-- Two-column layout container -->
       <div class="settings-columns">
         
-        <!-- Column 1: Classes -->
+        <!-- Column 1: Degree Slider and Classes -->
         <div class="settings-column">
+          <!-- New: Minimum Degree Slider -->
+          <div class="settings-section">
+            <h3 id="settings-min-degree-title"></h3>
+            <div id="settings-min-degree-container">
+              <!-- Slider will be dynamically populated by main.js -->
+            </div>
+          </div>
+          
           <div class="settings-section">
             <h3 id="settings-node-classes-title"></h3>
             <div id="settings-classes">

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,9 +33,14 @@
         <div class="settings-column">
           <div class="settings-section">
             <h3>General</h3>
-            <div class="settings-item">
-              <label for="settingsFocusMode">Focus Mode (hides Info Panel)</label>
-              <input type="checkbox" id="settingsFocusMode" />
+            <!-- UPDATED: Focus Mode now uses the standard list item structure -->
+            <div class="settings-list-item">
+                <div class="settings-list-item-content">
+                    <label>
+                        <input type="checkbox" id="settingsFocusMode">
+                        <strong>Focus Mode (hides Info Panel)</strong>
+                    </label>
+                </div>
             </div>
           </div>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -113,170 +113,133 @@ function setupSearchBox(onSearchChange) {
 }
 
 /**
+ * NEW: Selects the best localized text based on language preferences.
+ * @param {object} langMap - An object mapping lang codes to text (e.g., { de: 'Hallo', en: 'Hello' }).
+ * @param {string} currentLang - The desired language code.
+ * @returns {{text: string, lang: string, isFallback: boolean}}
+ */
+function getLocalizedText(langMap, currentLang) {
+    if (!langMap) return { text: '', lang: '', isFallback: true };
+    const langPrefs = [currentLang, 'en', 'de', 'fr', 'it', '']; // Added empty string for untagged literals
+    for (const lang of langPrefs) {
+        if (langMap[lang]) {
+            return {
+                text: langMap[lang],
+                lang: lang,
+                isFallback: lang !== currentLang
+            };
+        }
+    }
+    // Fallback to the first available language if none of the preferred ones match
+    const firstKey = Object.keys(langMap)[0];
+    if (firstKey) {
+        return { text: langMap[firstKey], lang: firstKey, isFallback: true };
+    }
+    return { text: '', lang: '', isFallback: true };
+}
+
+
+/**
+ * NEW: Processes raw SPARQL results into a structured map with all languages.
+ */
+function processSparqlResults(bindings, keyField, fields) {
+    const dataMap = {};
+    bindings.forEach(row => {
+        const key = row[keyField]?.value;
+        if (!key) return;
+
+        if (!dataMap[key]) {
+            dataMap[key] = {
+                id: key
+            };
+            if (row.group) dataMap[key].group = mapClassIriToGroup(row.group.value);
+            fields.forEach(f => dataMap[key][f] = {});
+        }
+
+        fields.forEach(f => {
+            if (row[f]) {
+                const lang = row[`${f}Lang`]?.value || '';
+                dataMap[key][f][lang] = row[f].value;
+            }
+        });
+    });
+    return dataMap;
+}
+
+/**
  * Main application initialization.
  */
 async function init() {
     // Initialize style constants by reading them from the CSS variables
     APP_CONFIG.initializeStylesFromCSS();
 
-    const currentLang = getParam("lang") || "de";
+    // --- STATE ---
+    let currentLang = getParam("lang") || "de";
     let pinnedNodeId = null,
         pinnedEdgeId = null;
+    let allNodesData = {},
+        allEdgesData = {},
+        allClassesData = {},
+        allPredicatesData = {},
+        allTitles = {};
+    let network, nodesDataset, edgesDataset; // Make network and datasets globally accessible in init()
+    // --- END STATE ---
 
     if (getParam("infopanel") === "false") {
         document.getElementById("infoPanel").classList.add("param-hidden");
     }
 
+    // --- DATA FETCHING & PROCESSING ---
     try {
-        const titleJson = await getSparqlData(TITLE_QUERY);
-        document.getElementById("systemmapTitle").textContent = titleJson.results.bindings[0]?.title.value || "System Map";
+        const [titleJson, classesJson, predicatesJson, nodesJson, edgesJson] = await Promise.all([
+            getSparqlData(TITLE_QUERY), getSparqlData(CLASS_QUERY), getSparqlData(PREDICATES_QUERY),
+            getSparqlData(NODE_QUERY), getSparqlData(EDGE_QUERY)
+        ]);
+
+        // Process nodes, classes, and predicates
+        allNodesData = processSparqlResults(nodesJson.results.bindings, 'id', ['name', 'comment', 'abbreviation']);
+        allClassesData = processSparqlResults(classesJson.results.bindings, 'iri', ['label', 'comment']);
+        allPredicatesData = processSparqlResults(predicatesJson.results.bindings, 'iri', ['label', 'comment']);
+        titleJson.results.bindings.forEach(row => {
+            if (row.title) allTitles[row.lang.value || ''] = row.title.value;
+        });
+        
+        // --- CORRECT: Custom processing for edges to create unique IDs ---
+        edgesJson.results.bindings.forEach(row => {
+            const from = row.from.value;
+            const to = row.to.value;
+            const property = row.property.value;
+            // Create a unique ID for each edge instance
+            const edgeId = `${from}-${property}-${to}`;
+
+            if (!allEdgesData[edgeId]) {
+                allEdgesData[edgeId] = {
+                    id: edgeId,    // Unique internal ID for vis.js
+                    iri: property, // The actual predicate IRI
+                    from: from,
+                    to: to,
+                    label: {},
+                    comment: {}
+                };
+            }
+
+            // Populate language maps for the edge
+            if (row.label) {
+                const lang = row.labelLang?.value || '';
+                allEdgesData[edgeId].label[lang] = row.label.value;
+            }
+            if (row.comment) {
+                const lang = row.commentLang?.value || '';
+                allEdgesData[edgeId].comment[lang] = row.comment.value;
+            }
+        });
+
+
     } catch (error) {
-        console.error("Error fetching title:", error);
+        console.error("Fatal error fetching or processing data:", error);
+        document.getElementById("systemmapTitle").textContent = "Error loading data";
+        return; // Stop execution
     }
-
-    const [classesJson, predicatesJson, nodesJson, edgesJson] = await Promise.all([
-        getSparqlData(CLASS_QUERY), getSparqlData(PREDICATES_QUERY),
-        getSparqlData(NODE_QUERY), getSparqlData(EDGE_QUERY)
-    ]);
-
-    // Create a map from group name to its translated label for the info panel chip
-    const classLabelsByGroup = {};
-    classesJson.results.bindings.forEach(row => {
-        const groupName = mapClassIriToGroup(row.iri.value);
-        classLabelsByGroup[groupName] = row.label.value || groupName;
-    });
-
-    setupSettingsPanel(classesJson.results.bindings, predicatesJson.results.bindings);
-
-    const nodes = nodesJson.results.bindings.map(row => {
-        const label = row.displayLabel.value;
-        const abbreviation = row.abbreviation.value;
-        const labelLang = row.displayLabel["xml:lang"] || "";
-        const htmlLabel = labelLang && labelLang !== currentLang ?
-            `<b>${labelLang.toUpperCase()}:</b> <i>${shortenLabel(label, abbreviation)}</i>` :
-            `<b>${shortenLabel(label, abbreviation)}</b>`;
-
-        const groupName = mapClassIriToGroup(row.group.value);
-        return {
-            id: row.id.value,
-            label: htmlLabel,
-            group: groupName,
-            data: {
-                iri: row.id.value,
-                fullLabel: label,
-                abbreviation,
-                comment: row.comment.value,
-                isFallback: labelLang && labelLang !== currentLang,
-                labelLang
-            }
-        };
-    });
-
-    const edges = edgesJson.results.bindings.map(row => {
-        const edge = {
-            from: row.from.value,
-            to: row.to.value,
-            label: row.label.value,
-            comment: row.comment.value,
-            iri: row.id.value
-        };
-
-        // Use central config for dashed predicates
-        if (APP_CONFIG.DASHED_PREDICATES.includes(edge.iri)) {
-            edge.dashes = [2, 10];
-            edge.length = 500;
-            edge.springConstant = 0.001;
-        }
-        return edge;
-    });
-
-    const nodesDataset = new vis.DataSet(nodes);
-    const edgesDataset = new vis.DataSet(edges);
-    const container = document.getElementById("network");
-    const data = {
-        nodes: nodesDataset,
-        edges: edgesDataset
-    };
-
-    const options = {
-        nodes: {
-            shape: "box",
-            widthConstraint: 150,
-            heightConstraint: 40,
-            chosen: {
-                node: (values, id, selected, hovering) => {
-                    // Only apply hover effect if no node is pinned, OR if the hovered
-                    // node is within the 2-hop distance of the pinned node.
-                    if (hovering) {
-                        let isDimmed = false;
-                        if (pinnedNodeId) {
-                            const distMap = getDistancesUpToTwoHops(network, pinnedNodeId);
-                            if (distMap[id] === undefined || distMap[id] > 2) {
-                                isDimmed = true;
-                            }
-                        }
-                        // Apply highlight only if the node is not dimmed
-                        if (!isDimmed) {
-                            values.borderWidth = 3;
-                            values.borderColor = "#000";
-                        }
-                    }
-                }
-            }
-        },
-        edges: {
-            width: 2,
-            selectionWidth: 1,
-            font: {
-                face: "Poppins",
-                color: "#000000"
-            },
-            chosen: false,
-            arrows: {
-                to: {
-                    enabled: true,
-                    scaleFactor: 0.8
-                }
-            },
-            color: {
-                color: '#000000',
-                highlight: '#000000',
-                inherit: false
-            }
-        },
-        groups: APP_CONFIG.GROUP_STYLES, // Use styles from config
-        interaction: {
-            hover: true,
-            dragNodes: true,
-            hoverConnectedEdges: false,
-            zoomView: true,
-            dragView: true
-        },
-        physics: {
-            enabled: true,
-            barnesHut: {
-                gravitationalConstant: -9000,
-                centralGravity: 0.05,
-                springLength: 250,
-                springConstant: 0.2
-            },
-            stabilization: {
-                iterations: 100
-            }
-        }
-    };
-
-    const network = new vis.Network(container, data, options);
-
-    // Get original styles from the central config
-    const originalStyles = Object.fromEntries(nodes.map(n => {
-        const style = APP_CONFIG.GROUP_STYLES[n.group] || APP_CONFIG.GROUP_STYLES.Other;
-        return [n.id, {
-            background: style.background,
-            border: style.border,
-            fontColor: style.font.color
-        }];
-    }));
 
     const infoPanel = document.getElementById("infoPanel");
 
@@ -286,9 +249,18 @@ async function init() {
     const applyAllStyles = () => {
         const searchTerm = (getParam("search") || "").toLowerCase();
         const distMap = pinnedNodeId ? getDistancesUpToTwoHops(network, pinnedNodeId) : null;
+        
+        const originalStyles = Object.fromEntries(nodesDataset.map(n => {
+            const style = APP_CONFIG.GROUP_STYLES[n.group] || APP_CONFIG.GROUP_STYLES.Other;
+            return [n.id, {
+                background: style.background,
+                border: style.border,
+                fontColor: style.font.color
+            }];
+        }));
 
         // Node styling
-        const nodeUpdates = nodes.map(n => {
+        const nodeUpdates = nodesDataset.map(n => {
             const originalStyle = originalStyles[n.id];
             let newColor = originalStyle.background;
             let newBorder = originalStyle.border;
@@ -308,13 +280,15 @@ async function init() {
                 }
             }
 
-            // Apply search highlighting, using the central config color
+            // Apply search highlighting
             if (searchTerm) {
+                const nodeData = allNodesData[n.id];
                 const isMatch = (
-                    (n.data.fullLabel || '').toLowerCase().includes(searchTerm) ||
-                    (n.data.comment || '').toLowerCase().includes(searchTerm) ||
-                    (n.data.abbreviation || '').toLowerCase().includes(searchTerm)
+                    Object.values(nodeData.name).some(val => val.toLowerCase().includes(searchTerm)) ||
+                    Object.values(nodeData.comment).some(val => val.toLowerCase().includes(searchTerm)) ||
+                    Object.values(nodeData.abbreviation).some(val => val.toLowerCase().includes(searchTerm))
                 );
+
                 if (isMatch) {
                     newColor = APP_CONFIG.SEARCH_HIGHLIGHT_COLOR.background;
                     newBorder = APP_CONFIG.SEARCH_HIGHLIGHT_COLOR.border;
@@ -338,10 +312,7 @@ async function init() {
         nodesDataset.update(nodeUpdates);
 
         // Edge styling logic
-        const allEdges = edgesDataset.get({
-            returnType: 'Array'
-        });
-        const edgeUpdates = allEdges.map(edge => {
+        const edgeUpdates = edgesDataset.map(edge => {
             let newColor = '#000000',
                 newWidth = 2,
                 fontUpdate = {
@@ -360,14 +331,12 @@ async function init() {
                     fontUpdate.color = '#00000000';
                     fontUpdate.strokeWidth = 0;
                 } else {
-                    const maxDist = Math.max(distFrom, distTo);
+                    const maxDist = Math.max(distFrom ?? 0, distTo ?? 0);
                     if (maxDist === 2) {
                         const dimRatio = 0.5;
                         newColor = blendHexColors('#000000', '#ffffff', dimRatio);
                         fontUpdate.color = blendHexColors('#000000', '#ffffff', dimRatio);
                         newWidth = 1;
-                    }
-                    else {
                     }
                 }
             }
@@ -383,8 +352,6 @@ async function init() {
         edgesDataset.update(edgeUpdates);
     };
 
-    setupSearchBox(applyAllStyles);
-    applyAllStyles();
 
     const showInfo = (html) => {
         infoPanel.innerHTML = html;
@@ -396,55 +363,16 @@ async function init() {
         infoPanel.classList.remove("fixed");
     };
 
-    // in main.js
+    const getNodeInfoHtml = (nodeId) => {
+        const nodeData = allNodesData[nodeId];
+        const { text: fullLabel, lang: labelLang, isFallback } = getLocalizedText(nodeData.name, currentLang);
+        const { text: abbreviation } = getLocalizedText(nodeData.abbreviation, currentLang);
+        const { text: comment } = getLocalizedText(nodeData.comment, currentLang);
+        const group = nodeData.group;
 
-    network.on("click", params => {
-        let clickedNodeId = params.nodes[0] || null;
-
-        // If a node is currently pinned, check if the newly clicked node is a dimmed one.
-        // If so, treat it as a click on the background to un-pin everything.
-        if (clickedNodeId && pinnedNodeId) {
-            const distMap = getDistancesUpToTwoHops(network, pinnedNodeId);
-            if (distMap[clickedNodeId] === undefined || distMap[clickedNodeId] > 2) {
-                clickedNodeId = null; // Ignore click on dimmed node
-            }
-        }
-
-        pinnedNodeId = clickedNodeId;
-        // Only select an edge if no node was selected
-        pinnedEdgeId = clickedNodeId ? null : params.edges[0] || null;
-
-        if (pinnedNodeId) {
-            const selectedNode = nodesDataset.get(pinnedNodeId);
-            showInfo(getNodeInfoHtml(selectedNode.data, selectedNode.group));
-        } else if (pinnedEdgeId) {
-            showInfo(getEdgeInfoHtml(edgesDataset.get(pinnedEdgeId)));
-        } else {
-            // This now correctly triggers when clicking the background OR a dimmed node
-            network.unselectAll();
-            hideInfo();
-        }
-
-        applyAllStyles();
-
-        if (pinnedNodeId || pinnedEdgeId) {
-            infoPanel.classList.add("fixed");
-        } else {
-            infoPanel.classList.remove("fixed");
-        }
-    });
-
-    const getNodeInfoHtml = ({
-        iri,
-        fullLabel,
-        abbreviation,
-        comment,
-        isFallback,
-        labelLang
-    }, group) => {
-        // Use styles from central config
         const chipStyle = APP_CONFIG.GROUP_STYLES[group] || APP_CONFIG.GROUP_STYLES.Other;
-        const chipLabel = classLabelsByGroup[group] || group;
+        const classIri = APP_CONFIG.GROUP_IRI_MAP[group];
+        const { text: chipLabel } = getLocalizedText(allClassesData[classIri]?.label, currentLang);
 
         const inlineStyle = `
             background-color: ${chipStyle.background};
@@ -452,47 +380,258 @@ async function init() {
             color: ${chipStyle.font.color};
         `;
 
-        const classChipHtml = `<span class="info-panel-chip" style="${inlineStyle}">${chipLabel}</span>`;
-
-        let titleHtml = '';
-        titleHtml += isFallback ? `${labelLang.toUpperCase()}: <i>${fullLabel}</i>` : fullLabel;
+        const classChipHtml = `<span class="info-panel-chip" style="${inlineStyle}">${chipLabel || group}</span>`;
+        let titleHtml = isFallback && labelLang ? `${labelLang.toUpperCase()}: <i>${fullLabel}</i>` : fullLabel;
         if (abbreviation) titleHtml += ` (${abbreviation})`;
-        titleHtml += '';
 
         let html = `
-            <a href="${iri}" target="_blank"><small><code>${shortenIri(iri)}</code></small></a>
+            <a href="${nodeData.id}" target="_blank"><small><code>${shortenIri(nodeData.id)}</code></small></a>
             <div class="info-panel-header">
                 <h4>${titleHtml} ${classChipHtml}</h4>
             </div>`;
-
-        if (comment) {
-            html += `<p class="info-panel-comment"><small>${comment}</small></p>`;
-        }
-
+        if (comment) html += `<p class="info-panel-comment"><small>${comment}</small></p>`;
         return html;
     };
 
-    const getEdgeInfoHtml = ({
-        iri,
-        label,
-        comment
-    }) => {
-        let html = iri ? `<a href="${iri}" target="_blank"><small><code>${shortenIri(iri)}</code></small></a><br/>` : '';
+    const getEdgeInfoHtml = (edgeId) => {
+        const edgeData = allEdgesData[edgeId];
+        const { text: label } = getLocalizedText(edgeData.label, currentLang);
+        const { text: comment } = getLocalizedText(edgeData.comment, currentLang);
+
+        // CORRECT: Use the edge's `iri` for the link, not its internal `id`.
+        let html = edgeData.iri ? `<a href="${edgeData.iri}" target="_blank"><small><code>${shortenIri(edgeData.iri)}</code></small></a><br/>` : '';
         html += `<h4>${label}</h4>`;
         if (comment) html += `<p><small>${comment}</small></p>`;
         return html;
     };
+
+
+    /**
+     * NEW: Updates all language-sensitive elements in the UI.
+     */
+    const updateUIForLanguage = () => {
+        // 1. Update Title
+        document.getElementById("systemmapTitle").textContent = getLocalizedText(allTitles, currentLang).text || "System Map";
+
+        // 2. Update Node Labels
+        const nodeUpdates = Object.values(allNodesData).map(nodeData => {
+            const { text: label, lang: labelLang, isFallback } = getLocalizedText(nodeData.name, currentLang);
+            const { text: abbreviation } = getLocalizedText(nodeData.abbreviation, currentLang);
+
+            const htmlLabel = isFallback && labelLang ?
+                `<b>${labelLang.toUpperCase()}:</b> <i>${shortenLabel(label, abbreviation)}</i>` :
+                `<b>${shortenLabel(label, abbreviation)}</b>`;
+
+            return { id: nodeData.id, label: htmlLabel };
+        });
+        if (nodesDataset) nodesDataset.update(nodeUpdates);
+
+        // 3. Update Edge Labels
+        const edgeUpdates = Object.values(allEdgesData).map(edgeData => {
+            const { text: label } = getLocalizedText(edgeData.label, currentLang);
+            return { id: edgeData.id, label };
+        });
+        if (edgesDataset) edgesDataset.update(edgeUpdates);
+
+        // 4. Update Info Panel if visible
+        if (!infoPanel.classList.contains("hidden")) {
+            if (pinnedNodeId) {
+                showInfo(getNodeInfoHtml(pinnedNodeId));
+            } else if (pinnedEdgeId) {
+                showInfo(getEdgeInfoHtml(pinnedEdgeId));
+            }
+        }
+        
+        // 5. Update settings panel if visible
+        if(!document.getElementById('settings-overlay').classList.contains('hidden')) {
+            populateSettings();
+        }
+    };
+
+
+    // --- INITIALIZE GRAPH & UI ---
+    
+    // Initial node creation for Vis.js
+    const initialNodes = Object.values(allNodesData).map(nodeData => ({
+        id: nodeData.id,
+        group: nodeData.group,
+        label: " " // will be populated by updateUIForLanguage
+    }));
+
+    // Initial edge creation for Vis.js
+    const initialEdges = Object.values(allEdgesData).map(edgeData => {
+        const edge = {
+            id: edgeData.id,
+            from: edgeData.from,
+            to: edgeData.to,
+            label: " " // will be populated by updateUIForLanguage
+        };
+        // CORRECT: Check against the predicate IRI stored in `edgeData.iri`
+        if (APP_CONFIG.DASHED_PREDICATES.includes(edgeData.iri)) {
+            edge.dashes = [2, 10];
+            edge.length = 500;
+            edge.springConstant = 0.001;
+        }
+        return edge;
+    });
+
+    nodesDataset = new vis.DataSet(initialNodes);
+    edgesDataset = new vis.DataSet(initialEdges);
+    
+    const container = document.getElementById("network");
+    const data = { nodes: nodesDataset, edges: edgesDataset };
+    const options = { /* ... your existing options ... */ 
+        nodes: { shape: "box", widthConstraint: 150, heightConstraint: 40, chosen: { node: (values, id, selected, hovering) => { if (hovering) { let isDimmed = false; if (pinnedNodeId) { const distMap = getDistancesUpToTwoHops(network, pinnedNodeId); if (distMap[id] === undefined || distMap[id] > 2) { isDimmed = true; } } if (!isDimmed) { values.borderWidth = 3; values.borderColor = "#000"; } } } } },
+        edges: { width: 2, selectionWidth: 1, font: { face: "Poppins", color: "#000000" }, chosen: false, arrows: { to: { enabled: true, scaleFactor: 0.8 } }, color: { color: '#000000', highlight: '#000000', inherit: false } },
+        groups: APP_CONFIG.GROUP_STYLES,
+        interaction: { hover: true, dragNodes: true, hoverConnectedEdges: false, zoomView: true, dragView: true },
+        physics: { enabled: true, barnesHut: { gravitationalConstant: -9000, centralGravity: 0.05, springLength: 250, springConstant: 0.2 }, stabilization: { iterations: 100 } }
+    };
+
+    network = new vis.Network(container, data, options);
+
+    // --- EVENT LISTENERS ---
+
+    setupSearchBox(applyAllStyles);
+    
+    setupSettingsPanel(
+      () => populateSettings(), // pass function to re-populate on open
+      () => { // on save
+        const params = {};
+        params.lang = currentLang; // Keep current language
+        params.infopanel = document.getElementById('settingsFocusMode').checked ? 'false' : null;
+        document.querySelectorAll('#settings-classes input').forEach(cb => {
+            params[cb.dataset.group.toLowerCase()] = cb.checked ? null : 'false';
+        });
+        const allPredicateKeys = Object.keys(APP_CONFIG.PREDICATE_MAP);
+        const selectedPreds = Array.from(document.querySelectorAll('#settings-predicates input')).filter(cb => cb.checked).map(cb => cb.dataset.key);
+        params.predicates = selectedPreds.length === allPredicateKeys.length ? null : selectedPreds.join(';');
+        setParamsAndReload(params);
+    });
+
+    network.on("click", params => {
+        let clickedNodeId = params.nodes[0] || null;
+
+        if (clickedNodeId && pinnedNodeId) {
+            const distMap = getDistancesUpToTwoHops(network, pinnedNodeId);
+            if (distMap[clickedNodeId] === undefined || distMap[clickedNodeId] > 2) {
+                clickedNodeId = null; 
+            }
+        }
+
+        pinnedNodeId = clickedNodeId;
+        pinnedEdgeId = clickedNodeId ? null : params.edges[0] || null;
+
+        if (pinnedNodeId) {
+            showInfo(getNodeInfoHtml(pinnedNodeId));
+        } else if (pinnedEdgeId) {
+            showInfo(getEdgeInfoHtml(pinnedEdgeId));
+        } else {
+            network.unselectAll();
+            hideInfo();
+        }
+        applyAllStyles();
+        infoPanel.classList.toggle("fixed", !!(pinnedNodeId || pinnedEdgeId));
+    });
+
+    // Language switcher logic
+    const languageSelector = document.getElementById('languageSelector');
+    languageSelector.value = currentLang;
+    languageSelector.addEventListener('change', (e) => {
+        currentLang = e.target.value;
+        setParamsWithoutReload({ lang: currentLang });
+        updateUIForLanguage();
+    });
+
+
+    // --- FINAL UI POPULATION ---
+    updateUIForLanguage(); // Initial population of all text
+    applyAllStyles(); // Initial application of styles
+
+
+    /**
+     * Populates the settings form with values from URL params and data.
+     */
+    function populateSettings() {
+        document.getElementById('settingsFocusMode').checked = getParam("infopanel") === "false";
+
+        const createCheckboxItem = (container, { id, dataKey, dataValue, isChecked, label, comment, uri, curie, swatchColor }) => {
+            let html = `<div class="settings-list-item">`;
+            if (swatchColor) html += `<div class="settings-list-swatch" style="background: ${swatchColor}; border-color: #555;"></div>`;
+            html += `<div class="settings-list-item-content">
+                        <label>
+                            <input type="checkbox" id="${id}" data-${dataKey}="${dataValue}" ${isChecked ? 'checked' : ''}>
+                            <strong>${label}</strong>
+                            <code class="settings-curie"><a href="${uri}" target="_blank">${curie}<a></code>
+                        </label>
+                        ${comment ? `<span class="settings-list-item-comment">${comment}</span>`:``}
+                    </div></div>`;
+            container.insertAdjacentHTML('beforeend', html);
+        };
+
+        const classesContainer = document.getElementById('settings-classes');
+        classesContainer.innerHTML = '';
+        Object.values(allClassesData).forEach(classData => {
+            const groupName = mapClassIriToGroup(classData.id);
+            createCheckboxItem(classesContainer, {
+                id: `setting-class-${groupName}`,
+                dataKey: 'group',
+                dataValue: groupName,
+                isChecked: getParam(groupName.toLowerCase()) !== "false",
+                label: getLocalizedText(classData.label, currentLang).text || 'No label',
+                comment: getLocalizedText(classData.comment, currentLang).text || '',
+                uri: classData.id,
+                curie: shortenIri(classData.id),
+                swatchColor: APP_CONFIG.GROUP_STYLES[groupName]?.background
+            });
+        });
+
+        const predicatesContainer = document.getElementById('settings-predicates');
+        predicatesContainer.innerHTML = '';
+        const rawPredParam = getParam("predicates");
+        const currentPreds = rawPredParam === null ? Object.keys(APP_CONFIG.PREDICATE_MAP) : (rawPredParam ? rawPredParam.split(/[;,+\s]+/) : []);
+
+        const iriToKeyMap = {};
+        const invertedPrefixes = Object.fromEntries(Object.entries(APP_CONFIG.PREFIXES).map(([base, prefix]) => [prefix, base]));
+        for (const [key, curie] of Object.entries(APP_CONFIG.PREDICATE_MAP)) {
+            const [prefix, suffix] = curie.split(':');
+            if (invertedPrefixes[prefix]) {
+                const iri = invertedPrefixes[prefix] + suffix;
+                iriToKeyMap[iri] = key;
+            }
+        }
+        
+        const sortedPredicates = Object.values(allPredicatesData).sort((a,b) => 
+            (getLocalizedText(a.label, currentLang).text || '').localeCompare(getLocalizedText(b.label, currentLang).text || '')
+        );
+
+        sortedPredicates.forEach(predData => {
+            const key = iriToKeyMap[predData.id];
+            if (key) {
+                createCheckboxItem(predicatesContainer, {
+                    id: `setting-pred-${key}`,
+                    dataKey: 'key',
+                    dataValue: key,
+                    isChecked: currentPreds.includes(key),
+                    label: getLocalizedText(predData.label, currentLang).text || 'No label',
+                    uri: predData.id,
+                    curie: shortenIri(predData.id)
+                });
+            }
+        });
+    }
 }
+
 
 /**
  * Manages the settings panel logic, events, and state.
  */
-function setupSettingsPanel(classRows, predicateRows) {
+function setupSettingsPanel(onOpen, onSave) {
     const overlay = document.getElementById('settings-overlay');
     const trigger = document.getElementById('settings-trigger');
 
     const openSettings = () => {
-        populateSettings(classRows, predicateRows);
+        onOpen(); // Callback to populate the panel
         overlay.classList.remove('hidden');
     };
     const closeSettings = () => overlay.classList.add('hidden');
@@ -505,104 +644,7 @@ function setupSettingsPanel(classRows, predicateRows) {
     overlay.addEventListener('click', (e) => {
         if (e.target === overlay) closeSettings();
     });
-
-    document.getElementById('settingsSave').addEventListener('click', () => {
-        const params = {};
-        params.lang = document.getElementById('settingsLanguage').value;
-        params.infopanel = document.getElementById('settingsFocusMode').checked ? 'false' : null;
-        document.querySelectorAll('#settings-classes input').forEach(cb => {
-            params[cb.dataset.group.toLowerCase()] = cb.checked ? null : 'false';
-        });
-
-        // Use central config for predicate keys
-        const allPredicateKeys = Object.keys(APP_CONFIG.PREDICATE_MAP);
-        const selectedPreds = Array.from(document.querySelectorAll('#settings-predicates input')).filter(cb => cb.checked).map(cb => cb.dataset.key);
-        params.predicates = selectedPreds.length === allPredicateKeys.length ? null : selectedPreds.join(';');
-
-        setParamsAndReload(params);
-    });
-}
-
-/**
- * Populates the settings form with values from URL params and SPARQL queries.
- */
-function populateSettings(classRows, predicateRows) {
-    document.getElementById('settingsLanguage').value = getParam("lang") || "de";
-    document.getElementById('settingsFocusMode').checked = getParam("infopanel") === "false";
-
-    const createCheckboxItem = (container, {
-        id,
-        dataKey,
-        dataValue,
-        isChecked,
-        label,
-        comment,
-        uri,
-        curie,
-        swatchColor
-    }) => {
-        let html = `<div class="settings-list-item">`;
-        if (swatchColor) html += `<div class="settings-list-swatch" style="background: ${swatchColor}; border-color: #555;"></div>`;
-        html += `<div class="settings-list-item-content">
-                    <label>
-                        <input type="checkbox" id="${id}" data-${dataKey}="${dataValue}" ${isChecked ? 'checked' : ''}>
-                        <strong>${label}</strong>
-                        <code class="settings-curie"><a href="${uri}" target="_blank">${curie}<a></code>
-                    </label>
-                    ${comment ? `<span class="settings-list-item-comment">${comment}</span>`:``}
-                </div></div>`;
-        container.insertAdjacentHTML('beforeend', html);
-    };
-
-    const classesContainer = document.getElementById('settings-classes');
-    classesContainer.innerHTML = '';
-    classRows.forEach(row => {
-        const groupName = mapClassIriToGroup(row.iri.value);
-        createCheckboxItem(classesContainer, {
-            id: `setting-class-${groupName}`,
-            dataKey: 'group',
-            dataValue: groupName,
-            isChecked: getParam(groupName.toLowerCase()) !== "false",
-            label: row.label.value || 'No label',
-            comment: row.comment.value || 'No comment',
-            uri: row.iri.value,
-            curie: shortenIri(row.iri.value),
-            swatchColor: APP_CONFIG.GROUP_STYLES[groupName]?.background
-        });
-    });
-
-    const predicatesContainer = document.getElementById('settings-predicates');
-    predicatesContainer.innerHTML = '';
-    const rawPredParam = getParam("predicates");
-    const currentPreds = rawPredParam === null ? Object.keys(APP_CONFIG.PREDICATE_MAP) : (rawPredParam ? rawPredParam.split(/[;,+\s]+/) : []);
-
-    // Create a map of full IRIs to their short keys (e.g., 'http://...#isPartOf' -> 'isPartOf')
-    const iriToKeyMap = {};
-    const invertedPrefixes = Object.fromEntries(
-        Object.entries(APP_CONFIG.PREFIXES).map(([base, prefix]) => [prefix, base])
-    );
-    for (const [key, curie] of Object.entries(APP_CONFIG.PREDICATE_MAP)) {
-        const [prefix, suffix] = curie.split(':');
-        if (invertedPrefixes[prefix]) {
-            const iri = invertedPrefixes[prefix] + suffix;
-            iriToKeyMap[iri] = key;
-        }
-    }
-
-    predicateRows.sort((a, b) => (a.label.value || '').localeCompare(b.label.value || '')).forEach(row => {
-        const key = iriToKeyMap[row.iri.value];
-        if (key) {
-            createCheckboxItem(predicatesContainer, {
-                id: `setting-pred-${key}`,
-                dataKey: 'key',
-                dataValue: key,
-                isChecked: currentPreds.includes(key),
-                label: row.label.value || 'No label',
-                uri: row.iri.value,
-                curie: shortenIri(row.iri.value)
-            });
-        }
-    });
+    document.getElementById('settingsSave').addEventListener('click', onSave);
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/docs/query.js
+++ b/docs/query.js
@@ -12,31 +12,24 @@ window.information = getQueryParam("information", "true") === "true" ? "dcat:Dat
 
 /* -------------------------------------------------------------
 Toggle which edge predicates are fetched.
-- The user passes  ?predicates=key1;key2;key3
-- Keys are defined in APP_CONFIG.PREDICATE_MAP in config.js.
-- If the param is missing or empty, we include *all* predicates.
 ----------------------------------------------------------------*/
 const rawPredParam = getQueryParam("predicates", "").trim();
 const selectedKeys = rawPredParam
   ? rawPredParam.split(/[;,+\s]+/).filter(Boolean)
   : [];
 
-// translate keys → prefixed IRIs; unknown keys are ignored
 let predicateIris = selectedKeys
   .map(k => APP_CONFIG.PREDICATE_MAP[k])
   .filter(Boolean);
 
-// If the user gave nothing valid, fall back to the full list
 if (predicateIris.length === 0) {
   predicateIris = Object.values(APP_CONFIG.PREDICATE_MAP);
 }
 
-// build a SPARQL-ready VALUES list string
 window.predicateValues = predicateIris
   .map(iri => `      ${iri}`)
   .join("\n");
 
-// set SPARQL endpoint from config
 window.ENDPOINT = APP_CONFIG.ENDPOINT;
 
 // query nodes - fetches all language data at once
@@ -60,7 +53,7 @@ WHERE {
 }
 `;
 
-// query edges between the nodes - fetches all language data at once
+// Simplified query for edge instances
 window.EDGE_QUERY = `
 PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX systemmap: <https://agriculture.ld.admin.ch/system-map/>
@@ -70,19 +63,48 @@ PREFIX prov:   <http://www.w3.org/ns/prov#>
 PREFIX service:<http://purl.org/ontology/service#>
 PREFIX dcterms:<http://purl.org/dc/terms/>
 
-SELECT ?property ?from ?to ?label ?labelLang ?comment ?commentLang
+SELECT ?from ?property ?to
 WHERE {
   GRAPH <https://lindas.admin.ch/foag/system-map> {
     ?from ?property ?to .
     VALUES ?property {
       ${predicateValues}
     }
-
-    OPTIONAL { ?property schema:name ?label . BIND(LANG(?label) as ?labelLang) }
-    OPTIONAL { ?property schema:description ?comment . BIND(LANG(?comment) as ?commentLang) }
   }
 }
 `;
+
+// NEW: Query for predicate metadata (labels, domain, range)
+window.EDGE_METADATA_QUERY = `
+PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX systemmap: <https://agriculture.ld.admin.ch/system-map/>
+PREFIX schema: <http://schema.org/>
+PREFIX dcat:   <http://www.w3.org/ns/dcat#>
+PREFIX prov:   <http://www.w3.org/ns/prov#>
+PREFIX service:<http://purl.org/ontology/service#>
+PREFIX dcterms:<http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?predicate ?label ?labelLang ?comment ?commentLang ?domain ?range
+WHERE {
+  GRAPH <https://lindas.admin.ch/foag/system-map> {
+    VALUES ?predicate {
+      dcterms:isPartOf prov:wasDerivedFrom schema:parentOrganization systemmap:operates
+      systemmap:owns systemmap:contains systemmap:usesMasterData schema:memberOf
+      service:provides service:consumes systemmap:access systemmap:references
+    }
+    
+    # This ensures we only get metadata for predicates that are actually in use
+    ?from ?predicate ?to .
+
+    OPTIONAL { ?predicate schema:name ?label . BIND(LANG(?label) as ?labelLang) }
+    OPTIONAL { ?predicate schema:description ?comment . BIND(LANG(?comment) as ?commentLang) }
+    OPTIONAL { ?predicate rdfs:domain/rdfs:subClassOf* ?domain . FILTER NOT EXISTS { ?domain rdfs:subClassOf ?domainParent } }
+    OPTIONAL { ?predicate rdfs:range/rdfs:subClassOf* ?range . FILTER NOT EXISTS { ?range rdfs:subClassOf ?rangeParent } }
+  }
+}
+ORDER BY ?domain
+`;
+
 
 // query top class names and comments - fetches all language data at once
 window.CLASS_QUERY = `
@@ -95,29 +117,6 @@ window.CLASS_QUERY = `
     GRAPH <https://lindas.admin.ch/foag/system-map> {
       VALUES ?iri { schema:Organization schema:SoftwareApplication dcat:Dataset service:Service }
       
-      OPTIONAL { ?iri schema:name ?label . BIND(LANG(?label) AS ?labelLang) }
-      OPTIONAL { ?iri schema:description ?comment . BIND(LANG(?comment) AS ?commentLang) }
-    }
-  }
-`;
-
-// Query all possible predicates - fetches all language data at once
-window.PREDICATES_QUERY = `
-  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-  PREFIX systemmap: <https://agriculture.ld.admin.ch/system-map/>
-  PREFIX schema: <http://schema.org/>
-  PREFIX dcat:   <http://www.w3.org/ns/dcat#>
-  PREFIX prov:   <http://www.w3.org/ns/prov#>
-  PREFIX service:<http://purl.org/ontology/service#>
-  PREFIX dcterms:<http://purl.org/dc/terms/>
-  SELECT ?iri ?label ?labelLang ?comment ?commentLang
-  WHERE {
-    GRAPH <https://lindas.admin.ch/foag/system-map> {
-      VALUES ?iri {
-        dcterms:isPartOf prov:wasDerivedFrom schema:parentOrganization systemmap:operates
-        systemmap:owns systemmap:contains systemmap:usesMasterData schema:memberOf
-        service:provides service:consumes systemmap:access systemmap:references
-      }
       OPTIONAL { ?iri schema:name ?label . BIND(LANG(?label) AS ?labelLang) }
       OPTIONAL { ?iri schema:description ?comment . BIND(LANG(?comment) AS ?commentLang) }
     }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -340,3 +340,54 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1.5;
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
+
+/* New Slider Styles */
+.settings-slider-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 5px 0;
+}
+
+.settings-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 60%;
+    height: 3px;
+    background: var(--color-grey);
+    border-radius: 5px;
+    outline: none;
+    opacity: 0.9;
+    transition: opacity .2s;
+}
+
+.settings-slider:hover {
+    opacity: 1;
+}
+
+.settings-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: var(--color-font-dimmed);
+    cursor: pointer;
+    border-radius: 50%;
+    border: 2px solid var(--color-background);
+}
+
+.settings-slider::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    background: var(--color-font-normal);
+    cursor: pointer;
+    border-radius: 50%;
+    border: 2px solid var(--color-background);
+}
+
+#min-degree-value {
+    font-weight: 600;
+    font-size: 16px;
+    min-width: 20px; /* to avoid layout shift */
+    text-align: center;
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -68,6 +68,7 @@ html, body {
     font-family: "Poppins", sans-serif;
     font-size: 14px;
     pointer-events: none;
+    z-index: 100; /* Ensure info panel is above language selector */
 }
 .info-panel.hidden {
     display: none;
@@ -88,6 +89,21 @@ html, body {
     font-family: "Poppins", sans-serif;
     font-size: 36px;
     z-index: 100;
+}
+/* Language Selector Styles */
+.language-selector-container {
+    position: absolute;
+    top: 15px;
+    right: 20px;
+    z-index: 99; /* Below the info panel */
+}
+#languageSelector {
+    padding: 5px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-grey);
+    font-family: "Poppins", sans-serif;
+    font-size: 12px;
+    background: var(--color-background);
 }
 /* SETTINGS POP-UP STYLES */
 #settings-overlay {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -125,7 +125,7 @@ html, body {
     background: var(--color-background);
     padding: 20px 30px;
     border-radius: 8px;
-    width: 1000px;
+    width: 1100px;
     max-width: 90vw;
     max-height: 85vh;
     display: flex;
@@ -157,30 +157,13 @@ html, body {
     padding-right: 15px;
 }
 .settings-column:first-child {
-    flex: 1;
+    flex: 2;
 }
 .settings-column:last-child {
-    flex: 1;
+    flex: 3;
 }
 .settings-section {
     margin-bottom: 15px;
-}
-.settings-item {
-    display: flex;
-    align-items: center;
-    padding: 8px 0;
-    font-size: 14px;
-}
-.settings-item label {
-    flex-grow: 1;
-}
-.settings-item select {
-    padding: 5px;
-    border-radius: 4px;
-}
-.settings-item input {
-    margin-left: 15px;
-    transform: scale(1.2);
 }
 .settings-list-item {
     display: flex;
@@ -188,29 +171,26 @@ html, body {
     margin-bottom: 12px;
     font-size: 14px;
 }
-.settings-list-swatch {
-    width: 24px;
-    height: 12px;
-    border: 1px solid var(--color-foreground);
-    border-radius: 3px;
-    margin-right: 12px;
-    flex-shrink: 0;
-    margin-top: 5px;
-}
 .settings-list-item-content {
     flex-grow: 1;
 }
 .settings-list-item-content label {
     display: flex;
     align-items: center;
+    flex-wrap: nowrap;
+    gap: 0.3rem;
+    width: 100%;
     margin-bottom: 4px;
+    cursor: pointer;
 }
 .settings-list-item-content input {
-    margin-right: 8px;
+    margin-right: 0;
     margin-left: 0;
+    flex-shrink: 0;
 }
 .settings-list-item-content strong {
-    margin-right: auto;
+    margin-right: 0; /* Remove right auto margin to allow left alignment */
+    white-space: nowrap;
 }
 .settings-list-item-comment {
     font-size: 9pt;
@@ -222,6 +202,7 @@ html, body {
     color: var(--color-font-dimmed);
     padding: 2px 4px;
     border-radius: 3px;
+    flex-shrink: 0; /* Prevent from shrinking */
 }
 .settings-actions {
     display: flex;
@@ -322,4 +303,40 @@ h1, h2, h3, h4, h5, h6 {
 }
 #infoPanel {
     word-wrap: break-word;
+}
+.edge-title-container {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 8px;
+}
+.edge-title-container h4 {
+    margin: 0 !important;
+}
+
+.edge-diagram {
+    display: flex;
+    align-items: center;
+    gap: 4px; /* Reduced gap */
+    flex-shrink: 0;
+}
+.edge-diagram-icon {
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    border-width: 1px;
+    border-style: solid;
+    white-space: nowrap;
+}
+.settings-node-icon {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    border-width: 1px;
+    border-style: solid;
+    white-space: nowrap;
+    line-height: 1.5;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }

--- a/rdf/ontology.ttl
+++ b/rdf/ontology.ttl
@@ -503,10 +503,10 @@ service:provides a owl:ObjectProperty ;
     owl:inverseOf service:providedBy .
 
 schema:member a owl:ObjectProperty ;
-    rdfs:label "hat Mitgliederorganisationen"@de,
-        "has member organizations"@en,
-        "a des organisations membres"@fr,
-        "ha organizzazioni membri"@it ;
+    rdfs:label "hat Mitglied"@de,
+        "has member"@en,
+        "a des membres"@fr,
+        "ha membri"@it ;
     rdfs:comment """
         Gibt an, dass eine Organisation X eine andere Organisation Y als Mitgliedsorganisation hat.
         Diese Beziehung stellt Mitgliedschaften in Branchenorganisationen, Berufsverbänden oder anderen formellen Vereinigungen dar, bei denen Organisationen als Mitglieder teilnehmen.
@@ -532,10 +532,10 @@ schema:member a owl:ObjectProperty ;
     owl:inverseOf schema:memberOf .
 
 schema:memberOf a owl:ObjectProperty ;
-    rdfs:label "ist eine Mitgliedsorganisation von"@de,
-        "is a member organization of"@en,
-        "est une organisation membre de"@fr,
-        "è un'organizzazione membro di"@it ;
+    rdfs:label "Mitglied von"@de,
+        "member of"@en,
+        "membre de"@fr,
+        "membro di"@it ;
     rdfs:comment """  
         Gibt an, dass eine Organisation X eine Mitgliedsorganisation einer anderen Organisation Y ist.
         Die Beziehung soll Mitgliedschaften von Branchenorganisationen, Berufsverbänden oder anderen formellen Vereinigungen darstellen, bei denen Organisationen als Mitglieder teilnehmen.


### PR DESCRIPTION
- Better handling of translations (all languages fetched in one go, JS code filters/selects languages) Closes #101.
- Removed "focus mode" not really necessary anymore given the cleaned up version of the system map.
- Add control for filtering based on node degree (degree-in + degree-out).
- Add translations for hard-coded elements.
- Work on #106