### PR TITLE
Simplify RDF data by removing unnecessary statement

### DIFF
--- a/rdf/data.ttl
+++ b/rdf/data.ttl
@@ -1328,8 +1328,7 @@ systemmap:SHFSc6xgsHF70IlUd a schema:SoftwareApplication ;
         "Linked Data Services LINDAS allow public administrations to publish their data in the form of Knowledge Graphs and make them accessible via https://lindas.admin.ch"@en,
         "Avec les services Linked Data LINDAS, les administrations publiques peuvent publier leurs données sous forme de graphe de connaissances et les rendre accessibles via https://lindas.admin.ch."@fr,
         "Con i Linked Data Services LINDAS, le pubbliche amministrazioni possono pubblicare i loro dati sotto forma di grafi di conoscenza e renderli accessibili attraverso https://lindas.admin.ch."@it ;
-    systemmap:operatedBy systemmap:S6VSaFePQaMGqU8vD ;
-    systemmap:contains [ a dcat:Dataset ; rdfs:label "DigiAgriFoodCH Systemlandkarte"@de ] .
+    systemmap:operatedBy systemmap:S6VSaFePQaMGqU8vD .
 
 systemmap:SHyBeGX0LsQwjJ6Z a schema:SoftwareApplication ;
     rdfs:label "Betriebs- und Unternehmensregister"@de,


### PR DESCRIPTION
Removed redundant 'systemmap:contains' statement from RDF data.