### PR TITLE
146 make haspartispartof properties more explicit

### DIFF
--- a/rdf/ontology.ttl
+++ b/rdf/ontology.ttl
@@ -60,7 +60,7 @@ dcat:Dataset a rdfs:Class,
         a owl:Restriction ;
         owl:onProperty dcat:keyword ;
         owl:allValuesFrom skos:Concept
-    ].
+    ] .
 
 dcmitype:Collection a owl:Class ;
     rdfs:label "Collection"@en ;
@@ -765,6 +765,10 @@ systemmap:containsNodes a owl:ObjectProperty ;
 systemmap:developedBy a owl:ObjectProperty ;
     rdfs:label "entwickelt von"@de,
         "developed by"@en ;
+    rdfs:domain [ 
+        a owl:Class ;
+        owl:unionOf ( dcat:Dataset service:Service schema:SoftwareApplication )
+    ] ;
     rdfs:range schema:Organization ;
     owl:inverseOf systemmap:develops .
 
@@ -778,7 +782,11 @@ systemmap:develops a owl:ObjectProperty ;
         Shows, what organization developed a system, a database or a service.
         """@en ;
     rdfs:domain schema:Organization ;
-    owl:inverseOf systemmap:developedBy .
+    owl:inverseOf systemmap:developedBy ;
+    rdfs:range [ 
+        a owl:Class ;
+        owl:unionOf ( dcat:Dataset service:Service schema:SoftwareApplication )
+    ] .
 
 systemmap:hasLegalBasis a owl:ObjectProperty ;
     rdfs:label "hat Rechtsgrundlage"@de,


### PR DESCRIPTION
- [Add restrictions on how to use dcterms:isPartOf/dcterms:hasPart](https://github.com/blw-ofag-ufag/system-map/pull/147/commits/d46d81a3946aa2f3ea4ae195d97519393b7cc74f)
- [Add keyword property](https://github.com/blw-ofag-ufag/system-map/pull/147/commits/96a390ec2e99875b242af43d58d3b9e7c8cc3247)
- [Define on what develops can be used](https://github.com/blw-ofag-ufag/system-map/pull/147/commits/6d390d73d153d258bb1ae573e89e0acbd06d556f)
- Closes #146